### PR TITLE
Release 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 If you like this project and find it useful, please consider giving it a star on GitHub at https://github.com/Luligu/matterbridge-shelly and sponsoring it.
 
-## [0.9.1] - 2024-08-28
+## [0.9.2] - 2024-08-28
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Added
 
 - [shelly]: When an already discovered and stored device is discovered with a new address, the change is registered and takes effect after restarting.
-- [shelly]: Added support for shellypro3em.
+- [shelly]: Added support for shellypro3em (monophase only).
 - [shelly]: Added a guide to add and debug BLU devices https://github.com/Luligu/matterbridge-shelly/blob/dev/BLU.md.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ If you like this project and find it useful, please consider giving it a star on
 - [package]: Updated dependencies.
 - [covers]: refactor Cover and Roller components for WindowCovering cluster.
 
-### Added
-
-- [plugin]: Added exposeInputEvent option to the config.
-- [shelly]: Added support for shelly0110dimg3.
-
 ### Fixed
 
 - [package]: Fixed dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
-- [shelly]: When an already discovered device is discovered with a new address, the change is registered and takes effect after restarting.
+- [shelly]: When an already discovered and stored device is discovered with a new address, the change is registered and takes effect after restarting.
 - [shelly]: Added support for shellypro3em.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 If you like this project and find it useful, please consider giving it a star on GitHub at https://github.com/Luligu/matterbridge-shelly and sponsoring it.
 
+## [0.9.3] - 2024-08-29
+
+### Fixed
+
+- [package]: Fixed WindowCovering.MovementStatus
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
+
 ## [0.9.2] - 2024-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 If you like this project and find it useful, please consider giving it a star on GitHub at https://github.com/Luligu/matterbridge-shelly and sponsoring it.
 
+## [0.9.1] - 2024-08-28
+
+### Changed
+
+- [package]: Updated dependencies.
+- [covers]: refactor Cover and Roller components for WindowCovering cluster.
+
+### Added
+
+- [plugin]: Added exposeInputEvent option to the config.
+- [shelly]: Added support for shelly0110dimg3.
+
+### Fixed
+
+- [package]: Fixed dependencies.
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
+
 ## [0.9.1] - 2024-08-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 - [shelly]: When an already discovered and stored device is discovered with a new address, the change is registered and takes effect after restarting.
 - [shelly]: Added support for shellypro3em.
+- [shelly]: Added a guide to add and debug BLU devices https://github.com/Luligu/matterbridge-shelly/blob/dev/BLU.md.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ If you like this project and find it useful, please consider giving it a star on
 
 ## [0.9.3] - 2024-08-29
 
+### Added
+
+- [shelly]: When an already discovered device is discovered with a new address, the change is registered and takes effect after restarting.
+- [shelly]: Added support for shellypro3em.
+
 ### Fixed
 
-- [package]: Fixed WindowCovering.MovementStatus
+- [shelly]: Fixed WindowCovering.MovementStatus for Gen. 1 rollers
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="./yellow-button.png" alt="Buy me a coffee" width="120">

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ For wifi battery-powered devices:
 
 For BLU devices:
 
-- BLU devices are supported through a local Shelly device acting as a ble gateway. To enable this feature, choose one or more devices that have the ble component and support the ble gateway (e.g. PRO and gen. 3 devices). In the gateway device web page, enable both "Enable Bluetooth" and "Enable Bluetooth gateway". Then, go to the "Components" section and add your BLU devices in "Bluetooth (BTHome) devices". Give a meaningful name to your device if desired and restart Matterbridge.
+- BLU devices are supported through a local Shelly device acting as a ble gateway. To enable this feature, choose one or more devices that have the ble component and support the ble gateway (e.g. PRO and gen. 3 devices). In the gateway device web page, enable both "Enable Bluetooth" and "Enable Bluetooth gateway". Then, go to the "Components" section and add your BLU devices in "Bluetooth (BTHome) devices". Give a meaningful name to your device if desired and restart Matterbridge. 
+See the full guide here: https://github.com/Luligu/matterbridge-shelly/blob/dev/BLU.md
 
 ## How to install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.2-beta2",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-shelly",
-      "version": "0.9.2-beta2",
+      "version": "0.9.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23,7 +23,7 @@
         "@types/eslint__js": "8.42.3",
         "@types/jest": "29.5.12",
         "@types/multicast-dns": "7.2.4",
-        "@types/node": "22.5.0",
+        "@types/node": "22.5.1",
         "@types/ws": "8.5.12",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-jest": "28.8.0",
@@ -1632,9 +1632,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
-      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
+      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.3-beta1",
+  "version": "0.9.3",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.2-beta2",
+  "version": "0.9.2",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.2",
+  "version": "0.9.3-beta1",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/eslint__js": "8.42.3",
     "@types/jest": "29.5.12",
     "@types/multicast-dns": "7.2.4",
-    "@types/node": "22.5.0",
+    "@types/node": "22.5.1",
     "@types/ws": "8.5.12",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-jest": "28.8.0",

--- a/src/mock/shellypro3em-A0DD6CA0C27C.mdns.json
+++ b/src/mock/shellypro3em-A0DD6CA0C27C.mdns.json
@@ -1,0 +1,117 @@
+{
+  "id": 0,
+  "type": "response",
+  "flags": 1024,
+  "flag_qr": true,
+  "opcode": "QUERY",
+  "flag_aa": true,
+  "flag_tc": false,
+  "flag_rd": false,
+  "flag_ra": false,
+  "flag_z": false,
+  "flag_ad": false,
+  "flag_cd": false,
+  "rcode": "NOERROR",
+  "questions": [],
+  "answers": [
+    {
+      "name": "_http._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shellypro3em-a0dd6ca0c27c._http._tcp.local"
+    },
+    {
+      "name": "_shelly._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shellypro3em-a0dd6ca0c27c._shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_http._tcp.local"
+    }
+  ],
+  "authorities": [],
+  "additionals": [
+    {
+      "name": "shellypro3em-a0dd6ca0c27c._http._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "ShellyPro3EM-A0DD6CA0C27C.local"
+      }
+    },
+    {
+      "name": "shellypro3em-a0dd6ca0c27c._http._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=2"
+      ]
+    },
+    {
+      "name": "ShellyPro3EM-A0DD6CA0C27C.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.80"
+    },
+    {
+      "name": "shellypro3em-a0dd6ca0c27c._shelly._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "ShellyPro3EM-A0DD6CA0C27C.local"
+      }
+    },
+    {
+      "name": "shellypro3em-a0dd6ca0c27c._shelly._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=2",
+        "app=Pro3EM",
+        "ver=1.4.3"
+      ]
+    },
+    {
+      "name": "ShellyPro3EM-A0DD6CA0C27C.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.80"
+    }
+  ]
+}

--- a/src/mock/shellypro3em-A0DD6CA0C27C.monophase.json
+++ b/src/mock/shellypro3em-A0DD6CA0C27C.monophase.json
@@ -1,0 +1,468 @@
+{
+  "shelly": {
+    "name": "Breaker box PRO-3EM",
+    "id": "shellypro3em-a0dd6ca0c27c",
+    "mac": "A0DD6CA0C27C",
+    "slot": 1,
+    "model": "SPEM-003CEBEU",
+    "gen": 2,
+    "fw_id": "20240822-121054/1.4.3-g143ff62",
+    "ver": "1.4.3",
+    "app": "Pro3EM",
+    "auth_en": false,
+    "auth_domain": null,
+    "profile": "monophase"
+  },
+  "settings": {
+    "ble": {
+      "enable": true,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": false
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": false,
+      "server": "iot.shelly.cloud:6012/jrpc"
+    },
+    "em1:0": {
+      "id": 0,
+      "name": null,
+      "reverse": false,
+      "ct_type": "120A"
+    },
+    "em1:1": {
+      "id": 1,
+      "name": null,
+      "reverse": false,
+      "ct_type": "120A"
+    },
+    "em1:2": {
+      "id": 2,
+      "name": null,
+      "reverse": false,
+      "ct_type": "120A"
+    },
+    "em1data:0": {},
+    "em1data:1": {},
+    "em1data:2": {},
+    "eth": {
+      "enable": true,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "modbus": {
+      "enable": true
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shellypro3em-a0dd6ca0c27c",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shellypro3em-a0dd6ca0c27c",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "sys": {
+      "device": {
+        "name": "Breaker box PRO-3EM",
+        "mac": "A0DD6CA0C27C",
+        "fw_id": "20240822-121054/1.4.3-g143ff62",
+        "discoverable": true,
+        "eco_mode": false,
+        "profile": "monophase",
+        "addon_type": null,
+        "sys_btn_toggle": true
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 9
+    },
+    "temperature:0": {
+      "id": 0,
+      "name": null,
+      "report_thr_C": 5,
+      "offset_C": 0
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "ShellyPro3EM-A0DD6CA0C27C",
+        "is_open": true,
+        "enable": true,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {
+      "errors": [
+        "observer_disabled"
+      ]
+    },
+    "cloud": {
+      "connected": false
+    },
+    "em1:0": {
+      "id": 0,
+      "current": 0.028,
+      "voltage": 0,
+      "act_power": 0,
+      "aprt_power": 0,
+      "pf": 0,
+      "freq": 0,
+      "calibration": "factory"
+    },
+    "em1:1": {
+      "id": 1,
+      "current": 0.028,
+      "voltage": 0,
+      "act_power": 0,
+      "aprt_power": 0,
+      "pf": 0,
+      "freq": 0,
+      "calibration": "factory"
+    },
+    "em1:2": {
+      "id": 2,
+      "current": 0.027,
+      "voltage": 236.1,
+      "act_power": 0,
+      "aprt_power": 6.5,
+      "pf": 0,
+      "freq": 50,
+      "calibration": "factory"
+    },
+    "em1data:0": {
+      "id": 0,
+      "total_act_energy": 0.01,
+      "total_act_ret_energy": 0
+    },
+    "em1data:1": {
+      "id": 1,
+      "total_act_energy": 0.01,
+      "total_act_ret_energy": 0
+    },
+    "em1data:2": {
+      "id": 2,
+      "total_act_energy": 0.01,
+      "total_act_ret_energy": 0.01
+    },
+    "eth": {
+      "ip": null
+    },
+    "modbus": {},
+    "mqtt": {
+      "connected": false
+    },
+    "sys": {
+      "mac": "A0DD6CA0C27C",
+      "restart_required": false,
+      "time": "16:49",
+      "unixtime": 1724856556,
+      "uptime": 4020,
+      "ram_size": 262000,
+      "ram_free": 91208,
+      "fs_size": 524288,
+      "fs_free": 180224,
+      "cfg_rev": 9,
+      "kvs_rev": 0,
+      "schedule_rev": 1,
+      "webhook_rev": 1,
+      "available_updates": {},
+      "reset_reason": 3
+    },
+    "temperature:0": {
+      "id": 0,
+      "tC": 47.9,
+      "tF": 118.2
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.80",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -58
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": true,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": false
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {
+        "errors": [
+          "observer_disabled"
+        ]
+      },
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": "iot.shelly.cloud:6012/jrpc"
+      }
+    },
+    {
+      "key": "em1:0",
+      "status": {
+        "id": 0,
+        "current": 0.028,
+        "voltage": 0,
+        "act_power": 0,
+        "aprt_power": 0,
+        "pf": 0,
+        "freq": 0,
+        "calibration": "factory"
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "reverse": false,
+        "ct_type": "120A"
+      }
+    },
+    {
+      "key": "em1:1",
+      "status": {
+        "id": 1,
+        "current": 0.028,
+        "voltage": 0,
+        "act_power": 0,
+        "aprt_power": 0,
+        "pf": 0,
+        "freq": 0,
+        "calibration": "factory"
+      },
+      "config": {
+        "id": 1,
+        "name": null,
+        "reverse": false,
+        "ct_type": "120A"
+      }
+    },
+    {
+      "key": "em1:2",
+      "status": {
+        "id": 2,
+        "current": 0.027,
+        "voltage": 236.1,
+        "act_power": 0,
+        "aprt_power": 6.5,
+        "pf": 0,
+        "freq": 50,
+        "calibration": "factory"
+      },
+      "config": {
+        "id": 2,
+        "name": null,
+        "reverse": false,
+        "ct_type": "120A"
+      }
+    },
+    {
+      "key": "em1data:0",
+      "status": {
+        "id": 0,
+        "total_act_energy": 0.01,
+        "total_act_ret_energy": 0
+      },
+      "config": {}
+    },
+    {
+      "key": "em1data:1",
+      "status": {
+        "id": 1,
+        "total_act_energy": 0.01,
+        "total_act_ret_energy": 0
+      },
+      "config": {}
+    },
+    {
+      "key": "em1data:2",
+      "status": {
+        "id": 2,
+        "total_act_energy": 0.01,
+        "total_act_ret_energy": 0.01
+      },
+      "config": {}
+    },
+    {
+      "key": "eth",
+      "status": {
+        "ip": null
+      },
+      "config": {
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      }
+    },
+    {
+      "key": "modbus",
+      "status": {},
+      "config": {
+        "enable": true
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shellypro3em-a0dd6ca0c27c",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shellypro3em-a0dd6ca0c27c",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "A0DD6CA0C27C",
+        "restart_required": false,
+        "time": "16:49",
+        "unixtime": 1724856557,
+        "uptime": 4021,
+        "ram_size": 261996,
+        "ram_free": 90012,
+        "fs_size": 524288,
+        "fs_free": 180224,
+        "cfg_rev": 9,
+        "kvs_rev": 0,
+        "schedule_rev": 1,
+        "webhook_rev": 1,
+        "available_updates": {},
+        "reset_reason": 3
+      },
+      "config": {
+        "device": {
+          "name": "Breaker box PRO-3EM",
+          "mac": "A0DD6CA0C27C",
+          "fw_id": "20240822-121054/1.4.3-g143ff62",
+          "discoverable": true,
+          "eco_mode": false,
+          "profile": "monophase",
+          "addon_type": null,
+          "sys_btn_toggle": true
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7312,
+          "lon": 7.4138
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 9
+      }
+    }
+  ]
+}

--- a/src/mock/shellypro3em-A0DD6CA0C27C.triphase.json
+++ b/src/mock/shellypro3em-A0DD6CA0C27C.triphase.json
@@ -1,0 +1,418 @@
+{
+  "shelly": {
+    "name": "Breaker box PRO-3EM",
+    "id": "shellypro3em-a0dd6ca0c27c",
+    "mac": "A0DD6CA0C27C",
+    "slot": 1,
+    "model": "SPEM-003CEBEU",
+    "gen": 2,
+    "fw_id": "20240822-121054/1.4.3-g143ff62",
+    "ver": "1.4.3",
+    "app": "Pro3EM",
+    "auth_en": false,
+    "auth_domain": null,
+    "profile": "triphase"
+  },
+  "settings": {
+    "ble": {
+      "enable": true,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": false
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": false,
+      "server": "iot.shelly.cloud:6012/jrpc"
+    },
+    "em:0": {
+      "id": 0,
+      "name": null,
+      "blink_mode_selector": "active_energy",
+      "phase_selector": "all",
+      "monitor_phase_sequence": false,
+      "ct_type": "120A",
+      "reverse": {}
+    },
+    "emdata:0": {},
+    "eth": {
+      "enable": true,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "modbus": {
+      "enable": true
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shellypro3em-a0dd6ca0c27c",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shellypro3em-a0dd6ca0c27c",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "sys": {
+      "device": {
+        "name": "Breaker box PRO-3EM",
+        "mac": "A0DD6CA0C27C",
+        "fw_id": "20240822-121054/1.4.3-g143ff62",
+        "discoverable": true,
+        "eco_mode": false,
+        "profile": "triphase",
+        "addon_type": null,
+        "sys_btn_toggle": true
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 10
+    },
+    "temperature:0": {
+      "id": 0,
+      "name": null,
+      "report_thr_C": 5,
+      "offset_C": 0
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "ShellyPro3EM-A0DD6CA0C27C",
+        "is_open": true,
+        "enable": true,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {
+      "errors": [
+        "observer_disabled"
+      ]
+    },
+    "cloud": {
+      "connected": false
+    },
+    "em:0": {
+      "id": 0,
+      "a_current": 0.029,
+      "a_voltage": 0,
+      "a_act_power": 0,
+      "a_aprt_power": 0,
+      "a_pf": 0,
+      "a_freq": 0,
+      "b_current": 0.027,
+      "b_voltage": 0,
+      "b_act_power": 0,
+      "b_aprt_power": 0,
+      "b_pf": 0,
+      "b_freq": 0,
+      "c_current": 0.027,
+      "c_voltage": 235.1,
+      "c_act_power": 0,
+      "c_aprt_power": 6.4,
+      "c_pf": 0,
+      "c_freq": 50,
+      "n_current": null,
+      "total_current": 0.083,
+      "total_act_power": 0,
+      "total_aprt_power": 6.426,
+      "user_calibrated_phase": []
+    },
+    "emdata:0": {
+      "id": 0,
+      "a_total_act_energy": 0.01,
+      "a_total_act_ret_energy": 0,
+      "b_total_act_energy": 0.01,
+      "b_total_act_ret_energy": 0,
+      "c_total_act_energy": 0.01,
+      "c_total_act_ret_energy": 0,
+      "total_act": 0.02,
+      "total_act_ret": 0
+    },
+    "eth": {
+      "ip": null
+    },
+    "modbus": {},
+    "mqtt": {
+      "connected": false
+    },
+    "sys": {
+      "mac": "A0DD6CA0C27C",
+      "restart_required": false,
+      "time": "16:51",
+      "unixtime": 1724856680,
+      "uptime": 23,
+      "ram_size": 261984,
+      "ram_free": 89136,
+      "fs_size": 524288,
+      "fs_free": 180224,
+      "cfg_rev": 10,
+      "kvs_rev": 0,
+      "schedule_rev": 2,
+      "webhook_rev": 2,
+      "available_updates": {},
+      "reset_reason": 3
+    },
+    "temperature:0": {
+      "id": 0,
+      "tC": 47.6,
+      "tF": 117.7
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.80",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -58
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": true,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": false
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {
+        "errors": [
+          "observer_disabled"
+        ]
+      },
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": "iot.shelly.cloud:6012/jrpc"
+      }
+    },
+    {
+      "key": "em:0",
+      "status": {
+        "id": 0,
+        "a_current": 0.028,
+        "a_voltage": 0,
+        "a_act_power": 0,
+        "a_aprt_power": 0,
+        "a_pf": 0,
+        "a_freq": 0,
+        "b_current": 0.027,
+        "b_voltage": 0,
+        "b_act_power": 0,
+        "b_aprt_power": 0,
+        "b_pf": 0,
+        "b_freq": 0,
+        "c_current": 0.028,
+        "c_voltage": 235.1,
+        "c_act_power": 0,
+        "c_aprt_power": 6.5,
+        "c_pf": 0,
+        "c_freq": 50,
+        "n_current": null,
+        "total_current": 0.083,
+        "total_act_power": 0,
+        "total_aprt_power": 6.544,
+        "user_calibrated_phase": []
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "blink_mode_selector": "active_energy",
+        "phase_selector": "all",
+        "monitor_phase_sequence": false,
+        "ct_type": "120A",
+        "reverse": {}
+      }
+    },
+    {
+      "key": "emdata:0",
+      "status": {
+        "id": 0,
+        "a_total_act_energy": 0.01,
+        "a_total_act_ret_energy": 0,
+        "b_total_act_energy": 0.01,
+        "b_total_act_ret_energy": 0,
+        "c_total_act_energy": 0.01,
+        "c_total_act_ret_energy": 0,
+        "total_act": 0.02,
+        "total_act_ret": 0
+      },
+      "config": {}
+    },
+    {
+      "key": "eth",
+      "status": {
+        "ip": null
+      },
+      "config": {
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      }
+    },
+    {
+      "key": "modbus",
+      "status": {},
+      "config": {
+        "enable": true
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shellypro3em-a0dd6ca0c27c",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shellypro3em-a0dd6ca0c27c",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "A0DD6CA0C27C",
+        "restart_required": false,
+        "time": "16:51",
+        "unixtime": 1724856680,
+        "uptime": 24,
+        "ram_size": 262052,
+        "ram_free": 91724,
+        "fs_size": 524288,
+        "fs_free": 180224,
+        "cfg_rev": 10,
+        "kvs_rev": 0,
+        "schedule_rev": 2,
+        "webhook_rev": 2,
+        "available_updates": {},
+        "reset_reason": 3
+      },
+      "config": {
+        "device": {
+          "name": "Breaker box PRO-3EM",
+          "mac": "A0DD6CA0C27C",
+          "fw_id": "20240822-121054/1.4.3-g143ff62",
+          "discoverable": true,
+          "eco_mode": false,
+          "profile": "triphase",
+          "addon_type": null,
+          "sys_btn_toggle": true
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7312,
+          "lon": 7.4138
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 10
+      }
+    }
+  ]
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -332,7 +332,6 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
               lightComponent.hasProperty('aenergy')
             ) {
               child.addClusterServer(
-                // mbDevice.getDefaultStaticEveHistoryClusterServer(
                 MatterHistory.getEveHistoryClusterServer(
                   lightComponent.getValue('voltage') as number,
                   lightComponent.getValue('current') as number,
@@ -430,7 +429,6 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
               switchComponent.hasProperty('aenergy')
             ) {
               child.addClusterServer(
-                // mbDevice.getDefaultStaticEveHistoryClusterServer(
                 MatterHistory.getEveHistoryClusterServer(
                   switchComponent.getValue('voltage') as number,
                   switchComponent.getValue('current') as number,
@@ -474,7 +472,6 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
               coverComponent.hasProperty('aenergy')
             ) {
               child.addClusterServer(
-                // mbDevice.getDefaultStaticEveHistoryClusterServer(
                 MatterHistory.getEveHistoryClusterServer(
                   coverComponent.getValue('voltage') as number,
                   coverComponent.getValue('current') as number,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -46,8 +46,6 @@ import {
   Switch,
   ColorControlCluster,
   electricalSensor,
-  ElectricalPowerMeasurement,
-  ElectricalEnergyMeasurement,
   OccupancySensingCluster,
   IlluminanceMeasurementCluster,
   TemperatureMeasurementCluster,
@@ -56,6 +54,8 @@ import {
   AtLeastOne,
   PowerSourceCluster,
 } from 'matterbridge';
+import { ElectricalPowerMeasurement, ElectricalEnergyMeasurement } from 'matterbridge/cluster';
+
 import { EveHistory, EveHistoryCluster, MatterHistory } from 'matterbridge/history';
 import { AnsiLogger, BLUE, CYAN, GREEN, LogLevel, TimestampFormat, YELLOW, db, debugStringify, dn, er, hk, idn, nf, or, rs, wr, zb } from 'matterbridge/logger';
 import { NodeStorage, NodeStorageManager } from 'matterbridge/storage';

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -129,8 +129,19 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
     // handle Shelly discovered event
     this.shelly.on('discovered', async (discoveredDevice: DiscoveredDevice) => {
       if (this.discoveredDevices.has(discoveredDevice.id)) {
-        this.log.info(`Shelly device ${hk}${discoveredDevice.id}${nf} host ${zb}${discoveredDevice.host}${nf} already discovered`);
-        return;
+        const stored = this.storedDevices.get(discoveredDevice.id);
+        if (stored?.host !== discoveredDevice.host) {
+          this.log.warn(`Shelly device ${hk}${discoveredDevice.id}${wr} host ${zb}${discoveredDevice.host}${wr} is already discovered with a different host.`);
+          this.log.warn(`Set new address for shelly device ${hk}${discoveredDevice.id}${wr} from ${zb}${stored?.host}${wr} to ${zb}${discoveredDevice.host}${wr}`);
+          this.log.warn(`Please restart for the change to take effect.`);
+          this.discoveredDevices.set(discoveredDevice.id, discoveredDevice);
+          this.storedDevices.set(discoveredDevice.id, discoveredDevice);
+          await this.saveStoredDevices();
+          return;
+        } else {
+          this.log.info(`Shelly device ${hk}${discoveredDevice.id}${nf} host ${zb}${discoveredDevice.host}${nf} already discovered`);
+          return;
+        }
       }
       this.discoveredDevices.set(discoveredDevice.id, discoveredDevice);
       this.storedDevices.set(discoveredDevice.id, discoveredDevice);

--- a/src/shellyDevice.real.test.ts
+++ b/src/shellyDevice.real.test.ts
@@ -16,7 +16,7 @@ describe('Shellies', () => {
   const shelly = new Shelly(log, 'admin', 'tango');
 
   const firmwareGen1 = '1.14.0-gcb84623';
-  const firmwareGen2 = '1.4.0-gb2aeadb';
+  const firmwareGen2 = '1.4.2-gc2639da';
 
   beforeAll(() => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {
@@ -82,7 +82,7 @@ describe('Shellies', () => {
       expect(device?.host).toBe('192.168.1.217');
       expect(device?.model).toBe('SNSW-001P16EU');
       expect(device?.id).toBe('shellyplus1pm-441793D69718');
-      expect(device?.firmware).toBe('1.4.2-beta1-g84969a6'); // firmwareGen2
+      expect(device?.firmware).toBe(firmwareGen2);
       expect(device?.auth).toBe(false);
 
       await device.fetchUpdate();
@@ -227,7 +227,7 @@ describe('Shellies', () => {
       expect(device?.host).toBe('192.168.1.218');
       expect(device?.model).toBe('SNSW-102P16EU');
       expect(device?.id).toBe('shellyplus2pm-5443B23D81F8');
-      expect(device?.firmware).toBe('1.4.2-beta1-g84969a6'); // firmwareGen2
+      expect(device?.firmware).toBe(firmwareGen2);
       expect(device?.auth).toBe(false);
 
       await device.fetchUpdate();
@@ -281,7 +281,7 @@ describe('Shellies', () => {
       expect(device.host).toBe('192.168.1.221');
       expect(device.model).toBe('S3SW-001X8EU');
       expect(device.id).toBe('shelly1minig3-543204547478');
-      expect(device.firmware).toBe(firmwareGen2); // firmwareGen2
+      expect(device.firmware).toBe(firmwareGen2);
       expect(device.auth).toBe(true);
 
       await device.fetchUpdate();

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -525,6 +525,7 @@ export class ShellyDevice extends EventEmitter {
         if (key.startsWith('input:')) device.addComponent(new ShellyComponent(device, key, 'Input', settingsPayload[key] as ShellyData));
         if (key.startsWith('pm1:')) device.addComponent(new ShellyComponent(device, key, 'PowerMeter', settingsPayload[key] as ShellyData));
         if (key.startsWith('em1:')) device.addComponent(new ShellyComponent(device, key, 'PowerMeter', settingsPayload[key] as ShellyData));
+        if (key.startsWith('em:')) device.addComponent(new ShellyComponent(device, key, 'PowerMeter', settingsPayload[key] as ShellyData));
         if (key.startsWith('temperature:')) device.addComponent(new ShellyComponent(device, key, 'Temperature', settingsPayload[key] as ShellyData));
         if (key.startsWith('humidity:')) device.addComponent(new ShellyComponent(device, key, 'Humidity', settingsPayload[key] as ShellyData));
       }
@@ -840,6 +841,9 @@ export class ShellyDevice extends EventEmitter {
         if (key.startsWith('input:')) this.updateComponent(key, data[key] as ShellyData);
         if (key.startsWith('pm1:')) this.updateComponent(key, data[key] as ShellyData);
         if (key.startsWith('em1:')) this.updateComponent(key, data[key] as ShellyData);
+        if (key.startsWith('emdata1:')) this.updateComponent(key.replace('emdata1:', 'em1:'), data[key] as ShellyData);
+        if (key.startsWith('em:')) this.updateComponent(key, data[key] as ShellyData);
+        if (key.startsWith('emdata:')) this.updateComponent(key.replace('emdata:', 'em:'), data[key] as ShellyData);
         if (key.startsWith('temperature:')) this.updateComponent(key, data[key] as ShellyData);
         if (key.startsWith('humidity:')) this.updateComponent(key, data[key] as ShellyData);
       }

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -35,7 +35,6 @@ import { WsClient } from './wsClient.js';
 import { Shelly } from './shelly.js';
 import { BTHomeComponent, BTHomeDeviceComponent, BTHomeSensorComponent, BTHomeStatusDevice, BTHomeStatusSensor, ShellyData, ShellyDataType } from './shellyTypes.js';
 import { isCoverComponent, isLightComponent, isSwitchComponent, ShellyComponent } from './shellyComponent.js';
-import {} from './platform.js';
 
 interface ShellyDeviceEvent {
   online: [];


### PR DESCRIPTION
## [0.9.3] - 2024-08-29

### Added

- [shelly]: When an already discovered and stored device is discovered with a new address, the change is registered and takes effect after restarting.
- [shelly]: Added support for shellypro3em (monophase only).
- [shelly]: Added a guide to add and debug BLU devices https://github.com/Luligu/matterbridge-shelly/blob/dev/BLU.md.

### Fixed

- [shelly]: Fixed WindowCovering.MovementStatus for Gen. 1 rollers

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>
