### PR TITLE
Release 0.9.7

### DIFF
--- a/.github/workflows/build-matterbridge-plugin.yml
+++ b/.github/workflows/build-matterbridge-plugin.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm install -g matterbridge --verbose
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
   
       - name: Lint the project
         run: npm run lint

--- a/.github/workflows/build-matterbridge-plugin.yml
+++ b/.github/workflows/build-matterbridge-plugin.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm -v
             
       - name: Install matterbridge
-        run: npm install -g matterbridge
+        run: npm install -g matterbridge --verbose
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/publish-matterbridge-plugin.yml
+++ b/.github/workflows/publish-matterbridge-plugin.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm install -g matterbridge
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
     
       - name: Lint the project
         run: npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 - [config]: Added option "postfix" to postfix the matter serial number to avoid eventual collisions with other devices on the network (default empty string).
 - [config]: Added option "failsafeCount" to avoid to start the bridge when some network issue prevents to load all devices (default 0 = disabled).
+- [matterbridge]: Added a check of the current Matterbridge version (required v1.5.4).
 
 ### Verified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
-- [config]: Added option "postfix" to postfix the matter serial number to avoid eventual collisionis with other devices on the network (default empty string).
+- [config]: Added option "postfix" to postfix the matter serial number to avoid eventual collisions with other devices on the network (default empty string).
 - [config]: Added option "failsafeCount" to avoid to start the bridge when some network issue prevents to load all devices (default 0 = disabled).
 
 ### Verified
 
-- [shelly]: Verified shellyprodm1pm with firmware v. 1.4.2 and added Jest test (this needs to be calibrated to enable level control).
+- [shelly]: Verified shellyprodm1pm with firmware v. 1.4.2 and added Jest test (this device needs to be calibrated to enable level control).
+- [shelly]: Verified shelly1g3 with firmware v. 1.4.2 and added Jest test.
+- [shelly]: Verified shelly1pmg3 with firmware v. 1.4.2 and added Jest test.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 - Unless you are using docker (in that case all is already updated when you pull the image), please update Matterbridge to 1.5.4 to work with matterbridge-shelly >= 0.9.5. This is a one time issue due to the update to matter.js 0.10.0.
 
-## [0.9.7] - 2024-09-08
+## [0.9.7] - 2024-09-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ If you like this project and find it useful, please consider giving it a star on
 
 ## [0.9.7] - 2024-09-08
 
+### Added
+
+- [config]: Added option "postfix" to postfix the matter serial number to avoid eventual collisionis with other devices on the network (default empty string).
+
 ### Verified
 
 - [shelly]: Verified shellyprodm1pm with firmware v. 1.4.2 and added Jest test (this needs to be calibrated to enable level control).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ If you like this project and find it useful, please consider giving it a star on
 - [shelly]: Verified shellyprodm1pm with firmware v. 1.4.2 and added Jest test (this device needs to be calibrated to enable level control).
 - [shelly]: Verified shelly1g3 with firmware v. 1.4.2 and added Jest test.
 - [shelly]: Verified shelly1pmg3 with firmware v. 1.4.2 and added Jest test.
+- [shelly]: Verified shellyi4g3 with firmware v. 1.4.2 and added Jest test.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Added
 
 - [config]: Added option "postfix" to postfix the matter serial number to avoid eventual collisionis with other devices on the network (default empty string).
+- [config]: Added option "failsafeCount" to avoid to start the bridge when some network issue prevents to load all devices (default 0 = disabled).
 
 ### Verified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Breaking Changes
 
-- Unless you are using docker (in that case all is already updated when you pull the image), please update Matterbridge to 1.5.4 to work with matterbridge-shelly >= 0.9.5. This is a one time issue due to the update to matter.js 0.10.0.
+- Unless you are using docker (in that case all is already updated when you pull the image), please update Matterbridge to 1.5.4 to work with matterbridge-shelly >= 0.9.5.  This is a one time issue due to the update to matter.js 0.10.0.
 
 ## [0.9.7] - 2024-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@ If you like this project and find it useful, please consider giving it a star on
 
 - Unless you are using docker (in that case all is already updated when you pull the image), please update Matterbridge to 1.5.4 to work with matterbridge-shelly >= 0.9.5. This is a one time issue due to the update to matter.js 0.10.0.
 
-## [0.9.6] - 2024-09-06
+## [0.9.7] - 2024-09-08
 
-### Added
+### Verified
+
+- [shelly]: Verified shellyprodm1pm with firmware v. 1.4.2 and added Jest test (this needs to be calibrated to enable level control).
+
+### Changed
+
+- [package]: Updated dependencies.
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
+
+## [0.9.6] - 2024-09-06
 
 ### Verified
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ A shelly device gen. 1 or 2 or 3 or BLU.
 
 For Gen. 1 devices:
 
-- CoIoT: the CoIoT (coap) service must be enabled in the settings of the device and the CoIoT peer must be mcast. If mcast is not working on your network put in the peer field "matterbridge-ipv4:5683" (e.g. 192.168.1.100:5683). You can find the matterbridge ipv4Address address in the frontend or in the log. Multicast may not work for all networks due to router or access poit configuration or network topology (I cannot help you on this, just check your router or access point configuration). If CoIoT is not configured correctly you will not receive any update from the device.
+- CoIoT: the CoIoT (coap) service must be enabled in the settings of the device and the CoIoT peer must be mcast. If mcast is not working on your network put in the peer field `<matterbridge-ipv4>:5683` (where `<matterbridge-ipv4>` is the ipv4 address of Matterbridge e.g. 192.168.1.100:5683). You can find the matterbridge ipv4Address address in the frontend or in the log. Multicast may not work for all networks due to router or access poit configuration or network topology (I cannot help you on this, just check your router or access point configuration). If CoIoT is not configured correctly you will not receive any update from the device.
 
 For wifi battery-powered devices:
 
 - Gen. 1: only for the first time, when you want to register them: check that enableMdnsDiscover and enableStorageDiscover are flagged in the plugin configuration. Restart matterbridge (the mdns discovery is active for the first 10 minutes) and awake each device you want to register pressing the device button.
 
-- Gen. 2/3: in the device web page go to "Settings", then "Outbound websocket" and enable it, select "TLS no validation" and put in the server field "ws://matterbridge-ipv4:8485" (e.g. ws://192.168.1.100:8485). You can find the matterbridge ipv4Address address in the frontend or in the log. Then, only for the first time, when you want to register them: check that enableMdnsDiscover and enableStorageDiscover are flagged in the plugin configuration. Restart matterbridge (the mdns discovery is active for the first 10 minutes) and awake each device you want to register pressing the device button.
+- Gen. 2/3: in the device web page go to "Settings", then "Outbound websocket" and enable it, select "TLS no validation" and put in the server field `ws://<matterbridge-ipv4>:8485` (where `<matterbridge-ipv4>` is the ipv4 address of Matterbridge e.g. ws://192.168.1.100:8485). You can find the matterbridge ipv4Address address in the frontend or in the log. Then, only for the first time, when you want to register them: check that enableMdnsDiscover and enableStorageDiscover are flagged in the plugin configuration. Restart matterbridge (the mdns discovery is active for the first 10 minutes) and awake each device you want to register pressing the device button.
 
 For BLU devices:
 

--- a/matterbridge-shelly.schema.json
+++ b/matterbridge-shelly.schema.json
@@ -107,6 +107,11 @@
       "type": "boolean",
       "default": true
     },
+    "postfix": {
+      "description": "Add this unique postfix to each device serial to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",
+      "type": "string",
+      "default": ""
+    },
     "debug": {
       "description": "Enable the debug for the plugin (development only)",
       "type": "boolean",

--- a/matterbridge-shelly.schema.json
+++ b/matterbridge-shelly.schema.json
@@ -108,7 +108,7 @@
       "default": true
     },
     "failsafeCount": {
-      "description": "Enable the failsafe count of added devices to put the plugin in error mode. This is to avoid to loose the controller configuration in case of network issues (default 0 = disabled).",
+      "description": "Enable the failsafe count of the devices registered. If the plugin registers less devices then the configured number, the plugin will go in error mode. This is to avoid to loose the controller configuration in case of network issues (default 0 = disabled).",
       "type": "number",
       "default": 0
     },

--- a/matterbridge-shelly.schema.json
+++ b/matterbridge-shelly.schema.json
@@ -113,7 +113,7 @@
       "default": 0
     },
     "postfix": {
-      "description": "Add this unique postfix to each device serial to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",
+      "description": "Add this unique postfix (3 characters max) to each device serial to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",
       "type": "string",
       "default": ""
     },

--- a/matterbridge-shelly.schema.json
+++ b/matterbridge-shelly.schema.json
@@ -107,6 +107,11 @@
       "type": "boolean",
       "default": true
     },
+    "failsafeCount": {
+      "description": "Enable the failsafe count of added devices to put the plugin in error mode. This is to avoid to loose the controller configuration in case of network issues (default 0 = disabled).",
+      "type": "number",
+      "default": 0
+    },
     "postfix": {
       "description": "Add this unique postfix to each device serial to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value or you may need to pair again the controller).",
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.7-dev.1",
+  "version": "0.9.7-dev.3",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.7-dev.3",
+  "version": "0.9.7-dev.4",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "start:frontend": "matterbridge",
+    "start": "matterbridge",
     "start:bridge": "matterbridge -bridge",
     "start:childbridge": "matterbridge -childbridge",
     "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.6",
+  "version": "0.9.7-dev.1",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "0.9.7-dev.4",
+  "version": "0.9.7",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -123,8 +123,5 @@
     "ts-jest": "29.2.5",
     "typescript": "5.5.4",
     "typescript-eslint": "8.3.0"
-  },
-  "xxxoverrides": {
-    "eslint": "latest"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,7 +10,14 @@ describe('initializePlugin', () => {
   let mockConfig: PlatformConfig;
 
   beforeEach(() => {
-    mockMatterbridge = { matterbridgePluginDirectory: 'temp', addBridgedDevice: jest.fn() } as unknown as Matterbridge;
+    mockMatterbridge = {
+      addBridgedDevice: jest.fn(),
+      matterbridgeDirectory: '',
+      matterbridgePluginDirectory: 'temp',
+      systemInformation: { ipv4Address: undefined },
+      matterbridgeVersion: '1.5.4',
+      removeAllBridgedDevices: jest.fn(),
+    } as unknown as Matterbridge;
     mockLog = { fatal: jest.fn(), error: jest.fn(), warn: jest.fn(), notice: jest.fn(), info: jest.fn(), debug: jest.fn() } as unknown as AnsiLogger;
     mockConfig = {
       'name': 'matterbridge-shelly',

--- a/src/mdnsScanner.ts
+++ b/src/mdnsScanner.ts
@@ -128,10 +128,10 @@ export class MdnsScanner extends EventEmitter {
     }
 
     this.scanner.on('response', async (response: ResponsePacket, rinfo: RemoteInfo) => {
-      let port = 0;
+      let port = 80; // shellymotionsensor, shellymotion2 send A record before SRV
       let gen = 1;
       this.devices.set(rinfo.address, rinfo.address);
-      if (debug) this.log.debug(`Mdns response from ${ign} ${rinfo.address} ${rinfo.family} ${rinfo.port} ${db}`);
+      if (debug) this.log.debug(`Mdns response from ${ign} ${rinfo.address} family ${rinfo.family} port ${rinfo.port} ${db}`);
       if (debug) this.log.debug(`--- response.answers ---`);
       for (const a of response.answers) {
         if (debug && a.type === 'PTR') {

--- a/src/mock/shelly1g3-34B7DACAC830.json
+++ b/src/mock/shelly1g3-34B7DACAC830.json
@@ -1,0 +1,396 @@
+{
+  "shelly": {
+    "name": "My Shelly 1 Gen3",
+    "id": "shelly1g3-34b7dacac830",
+    "mac": "34B7DACAC830",
+    "slot": 1,
+    "model": "S3SW-001X16EU",
+    "gen": 3,
+    "fw_id": "20240819-074630/1.4.2-gc2639da",
+    "ver": "1.4.2",
+    "app": "S1G3",
+    "auth_en": false,
+    "auth_domain": null
+  },
+  "settings": {
+    "ble": {
+      "enable": false,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": false
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": true,
+      "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+    },
+    "input:0": {
+      "id": 0,
+      "name": null,
+      "type": "switch",
+      "enable": true,
+      "invert": false,
+      "factory_reset": true
+    },
+    "knx": {
+      "enable": false,
+      "ia": "15.15.255",
+      "routing": {
+        "addr": "224.0.23.12:3671"
+      }
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shelly1g3-34b7dacac830",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shelly1g3-34b7dacac830",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "switch:0": {
+      "id": 0,
+      "name": null,
+      "in_mode": "follow",
+      "initial_state": "match_input",
+      "auto_on": false,
+      "auto_on_delay": 60,
+      "auto_off": false,
+      "auto_off_delay": 60
+    },
+    "sys": {
+      "device": {
+        "name": "My Shelly 1 Gen3",
+        "mac": "34B7DACAC830",
+        "fw_id": "20240819-074630/1.4.2-gc2639da",
+        "discoverable": true,
+        "eco_mode": false,
+        "addon_type": null
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 14
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "Shelly1G3-34B7DACAC830",
+        "is_open": true,
+        "enable": false,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {
+      "errors": [
+        "bluetooth_disabled"
+      ]
+    },
+    "cloud": {
+      "connected": true
+    },
+    "input:0": {
+      "id": 0,
+      "state": false
+    },
+    "knx": {},
+    "mqtt": {
+      "connected": false
+    },
+    "switch:0": {
+      "id": 0,
+      "source": "WS_in",
+      "output": false,
+      "temperature": {
+        "tC": 45.5,
+        "tF": 113.9
+      }
+    },
+    "sys": {
+      "mac": "34B7DACAC830",
+      "restart_required": false,
+      "time": "23:21",
+      "unixtime": 1725744078,
+      "uptime": 194,
+      "ram_size": 259336,
+      "ram_free": 134980,
+      "fs_size": 1048576,
+      "fs_free": 589824,
+      "cfg_rev": 14,
+      "kvs_rev": 0,
+      "schedule_rev": 0,
+      "webhook_rev": 0,
+      "available_updates": {},
+      "reset_reason": 3
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.157",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -61
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": false,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": false
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {
+        "errors": [
+          "bluetooth_disabled"
+        ]
+      },
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": true
+      },
+      "config": {
+        "enable": true,
+        "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+      }
+    },
+    {
+      "key": "input:0",
+      "status": {
+        "id": 0,
+        "state": false
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "type": "switch",
+        "enable": true,
+        "invert": false,
+        "factory_reset": true
+      }
+    },
+    {
+      "key": "knx",
+      "status": {},
+      "config": {
+        "enable": false,
+        "ia": "15.15.255",
+        "routing": {
+          "addr": "224.0.23.12:3671"
+        }
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shelly1g3-34b7dacac830",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shelly1g3-34b7dacac830",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "switch:0",
+      "status": {
+        "id": 0,
+        "source": "WS_in",
+        "output": false,
+        "temperature": {
+          "tC": 45.5,
+          "tF": 113.9
+        }
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "in_mode": "follow",
+        "initial_state": "match_input",
+        "auto_on": false,
+        "auto_on_delay": 60,
+        "auto_off": false,
+        "auto_off_delay": 60
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "34B7DACAC830",
+        "restart_required": false,
+        "time": "23:21",
+        "unixtime": 1725744079,
+        "uptime": 194,
+        "ram_size": 259328,
+        "ram_free": 133180,
+        "fs_size": 1048576,
+        "fs_free": 589824,
+        "cfg_rev": 14,
+        "kvs_rev": 0,
+        "schedule_rev": 0,
+        "webhook_rev": 0,
+        "available_updates": {},
+        "reset_reason": 3
+      },
+      "config": {
+        "device": {
+          "name": "My Shelly 1 Gen3",
+          "mac": "34B7DACAC830",
+          "fw_id": "20240819-074630/1.4.2-gc2639da",
+          "discoverable": true,
+          "eco_mode": false,
+          "addon_type": null
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7314,
+          "lon": 7.419
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 14
+      }
+    },
+    {
+      "key": "wifi",
+      "status": {
+        "sta_ip": "192.168.1.157",
+        "status": "got ip",
+        "ssid": "FibreBox_X6-12A4C7",
+        "rssi": -61
+      },
+      "config": {
+        "ap": {
+          "ssid": "Shelly1G3-34B7DACAC830",
+          "is_open": true,
+          "enable": false,
+          "range_extender": {
+            "enable": false
+          }
+        },
+        "sta": {
+          "ssid": "FibreBox_X6-12A4C7",
+          "is_open": false,
+          "enable": true,
+          "ipv4mode": "dhcp",
+          "ip": null,
+          "netmask": null,
+          "gw": null,
+          "nameserver": null
+        },
+        "sta1": {
+          "ssid": null,
+          "is_open": true,
+          "enable": false,
+          "ipv4mode": "dhcp",
+          "ip": null,
+          "netmask": null,
+          "gw": null,
+          "nameserver": null
+        },
+        "roam": {
+          "rssi_thr": -80,
+          "interval": 60
+        }
+      }
+    }
+  ]
+}

--- a/src/mock/shelly1g3-34B7DACAC830.mdns.json
+++ b/src/mock/shelly1g3-34B7DACAC830.mdns.json
@@ -1,0 +1,117 @@
+{
+  "id": 0,
+  "type": "response",
+  "flags": 1024,
+  "flag_qr": true,
+  "opcode": "QUERY",
+  "flag_aa": true,
+  "flag_tc": false,
+  "flag_rd": false,
+  "flag_ra": false,
+  "flag_z": false,
+  "flag_ad": false,
+  "flag_cd": false,
+  "rcode": "NOERROR",
+  "questions": [],
+  "answers": [
+    {
+      "name": "_http._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shelly1g3-34b7dacac830._http._tcp.local"
+    },
+    {
+      "name": "_shelly._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shelly1g3-34b7dacac830._shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_http._tcp.local"
+    }
+  ],
+  "authorities": [],
+  "additionals": [
+    {
+      "name": "shelly1g3-34b7dacac830._http._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "Shelly1G3-34B7DACAC830.local"
+      }
+    },
+    {
+      "name": "shelly1g3-34b7dacac830._http._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=3"
+      ]
+    },
+    {
+      "name": "Shelly1G3-34B7DACAC830.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.157"
+    },
+    {
+      "name": "shelly1g3-34b7dacac830._shelly._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "Shelly1G3-34B7DACAC830.local"
+      }
+    },
+    {
+      "name": "shelly1g3-34b7dacac830._shelly._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=3",
+        "app=S1G3",
+        "ver=1.4.2"
+      ]
+    },
+    {
+      "name": "Shelly1G3-34B7DACAC830.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.157"
+    }
+  ]
+}

--- a/src/mock/shelly1pmg3-34B7DAC68344.json
+++ b/src/mock/shelly1pmg3-34B7DAC68344.json
@@ -1,0 +1,405 @@
+{
+  "shelly": {
+    "name": "My Shelly 1PM Gen3",
+    "id": "shelly1pmg3-34b7dac68344",
+    "mac": "34B7DAC68344",
+    "slot": 1,
+    "model": "S3SW-001P16EU",
+    "gen": 3,
+    "fw_id": "20240819-074639/1.4.2-gc2639da",
+    "ver": "1.4.2",
+    "app": "S1PMG3",
+    "auth_en": false,
+    "auth_domain": null
+  },
+  "settings": {
+    "ble": {
+      "enable": false,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": false
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": true,
+      "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+    },
+    "input:0": {
+      "id": 0,
+      "name": null,
+      "type": "switch",
+      "enable": true,
+      "invert": false,
+      "factory_reset": true
+    },
+    "knx": {
+      "enable": false,
+      "ia": "15.15.255",
+      "routing": {
+        "addr": "224.0.23.12:3671"
+      }
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shelly1pmg3-34b7dac68344",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shelly1pmg3-34b7dac68344",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "switch:0": {
+      "id": 0,
+      "name": null,
+      "in_mode": "follow",
+      "initial_state": "match_input",
+      "auto_on": false,
+      "auto_on_delay": 60,
+      "auto_off": false,
+      "auto_off_delay": 60,
+      "power_limit": 4480,
+      "voltage_limit": 280,
+      "autorecover_voltage_errors": false,
+      "current_limit": 16
+    },
+    "sys": {
+      "device": {
+        "name": "My Shelly 1PM Gen3",
+        "mac": "34B7DAC68344",
+        "fw_id": "20240819-074639/1.4.2-gc2639da",
+        "discoverable": true,
+        "eco_mode": false,
+        "addon_type": null
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 12
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "Shelly1PMG3-34B7DAC68344",
+        "is_open": true,
+        "enable": false,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {
+      "errors": [
+        "bluetooth_disabled"
+      ]
+    },
+    "cloud": {
+      "connected": true
+    },
+    "input:0": {
+      "id": 0,
+      "state": false
+    },
+    "knx": {},
+    "mqtt": {
+      "connected": false
+    },
+    "switch:0": {
+      "id": 0,
+      "source": "HTTP_in",
+      "output": false,
+      "apower": 0,
+      "voltage": 237.1,
+      "freq": 50,
+      "current": 0,
+      "aenergy": {
+        "total": 0,
+        "by_minute": [
+          0,
+          0,
+          0
+        ],
+        "minute_ts": 1725745200
+      },
+      "ret_aenergy": {
+        "total": 0,
+        "by_minute": [
+          0,
+          0,
+          0
+        ],
+        "minute_ts": 1725745200
+      },
+      "temperature": {
+        "tC": 47.8,
+        "tF": 118.1
+      }
+    },
+    "sys": {
+      "mac": "34B7DAC68344",
+      "restart_required": false,
+      "time": "23:40",
+      "unixtime": 1725745201,
+      "uptime": 267,
+      "ram_size": 258688,
+      "ram_free": 129920,
+      "fs_size": 1048576,
+      "fs_free": 585728,
+      "cfg_rev": 12,
+      "kvs_rev": 0,
+      "schedule_rev": 1,
+      "webhook_rev": 0,
+      "available_updates": {},
+      "reset_reason": 3
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.158",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -47
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": false,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": false
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {
+        "errors": [
+          "bluetooth_disabled"
+        ]
+      },
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": true
+      },
+      "config": {
+        "enable": true,
+        "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+      }
+    },
+    {
+      "key": "input:0",
+      "status": {
+        "id": 0,
+        "state": false
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "type": "switch",
+        "enable": true,
+        "invert": false,
+        "factory_reset": true
+      }
+    },
+    {
+      "key": "knx",
+      "status": {},
+      "config": {
+        "enable": false,
+        "ia": "15.15.255",
+        "routing": {
+          "addr": "224.0.23.12:3671"
+        }
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shelly1pmg3-34b7dac68344",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shelly1pmg3-34b7dac68344",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "switch:0",
+      "status": {
+        "id": 0,
+        "source": "HTTP_in",
+        "output": false,
+        "apower": 0,
+        "voltage": 237,
+        "freq": 50,
+        "current": 0,
+        "aenergy": {
+          "total": 0,
+          "by_minute": [
+            0,
+            0,
+            0
+          ],
+          "minute_ts": 1725745200
+        },
+        "ret_aenergy": {
+          "total": 0,
+          "by_minute": [
+            0,
+            0,
+            0
+          ],
+          "minute_ts": 1725745200
+        },
+        "temperature": {
+          "tC": 47.8,
+          "tF": 118.1
+        }
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "in_mode": "follow",
+        "initial_state": "match_input",
+        "auto_on": false,
+        "auto_on_delay": 60,
+        "auto_off": false,
+        "auto_off_delay": 60,
+        "power_limit": 4480,
+        "voltage_limit": 280,
+        "autorecover_voltage_errors": false,
+        "current_limit": 16
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "34B7DAC68344",
+        "restart_required": false,
+        "time": "23:40",
+        "unixtime": 1725745201,
+        "uptime": 267,
+        "ram_size": 258684,
+        "ram_free": 128260,
+        "fs_size": 1048576,
+        "fs_free": 585728,
+        "cfg_rev": 12,
+        "kvs_rev": 0,
+        "schedule_rev": 1,
+        "webhook_rev": 0,
+        "available_updates": {},
+        "reset_reason": 3
+      },
+      "config": {
+        "device": {
+          "name": "My Shelly 1PM Gen3",
+          "mac": "34B7DAC68344",
+          "fw_id": "20240819-074639/1.4.2-gc2639da",
+          "discoverable": true,
+          "eco_mode": false,
+          "addon_type": null
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7314,
+          "lon": 7.419
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 12
+      }
+    }
+  ]
+}

--- a/src/mock/shelly1pmg3-34B7DAC68344.mdns.json
+++ b/src/mock/shelly1pmg3-34B7DAC68344.mdns.json
@@ -1,0 +1,117 @@
+{
+  "id": 0,
+  "type": "response",
+  "flags": 1024,
+  "flag_qr": true,
+  "opcode": "QUERY",
+  "flag_aa": true,
+  "flag_tc": false,
+  "flag_rd": false,
+  "flag_ra": false,
+  "flag_z": false,
+  "flag_ad": false,
+  "flag_cd": false,
+  "rcode": "NOERROR",
+  "questions": [],
+  "answers": [
+    {
+      "name": "_http._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shelly1pmg3-34b7dac68344._http._tcp.local"
+    },
+    {
+      "name": "_shelly._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shelly1pmg3-34b7dac68344._shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_http._tcp.local"
+    }
+  ],
+  "authorities": [],
+  "additionals": [
+    {
+      "name": "shelly1pmg3-34b7dac68344._http._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "Shelly1PMG3-34B7DAC68344.local"
+      }
+    },
+    {
+      "name": "shelly1pmg3-34b7dac68344._http._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=3"
+      ]
+    },
+    {
+      "name": "Shelly1PMG3-34B7DAC68344.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.158"
+    },
+    {
+      "name": "shelly1pmg3-34b7dac68344._shelly._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "Shelly1PMG3-34B7DAC68344.local"
+      }
+    },
+    {
+      "name": "shelly1pmg3-34b7dac68344._shelly._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=3",
+        "app=S1PMG3",
+        "ver=1.4.2"
+      ]
+    },
+    {
+      "name": "Shelly1PMG3-34B7DAC68344.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.158"
+    }
+  ]
+}

--- a/src/mock/shellyi4g3-5432045661B4.json
+++ b/src/mock/shellyi4g3-5432045661B4.json
@@ -1,0 +1,393 @@
+{
+  "shelly": {
+    "name": "My Shelly i4 Gen3",
+    "id": "shellyi4g3-5432045661b4",
+    "mac": "5432045661B4",
+    "slot": 1,
+    "model": "S3SN-0024X",
+    "gen": 3,
+    "fw_id": "20240819-074305/1.4.2-gc2639da",
+    "ver": "1.4.2",
+    "app": "I4G3",
+    "auth_en": false,
+    "auth_domain": null
+  },
+  "settings": {
+    "ble": {
+      "enable": false,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": false
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": true,
+      "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+    },
+    "input:0": {
+      "id": 0,
+      "name": null,
+      "type": "switch",
+      "enable": true,
+      "invert": false,
+      "factory_reset": true
+    },
+    "input:1": {
+      "id": 1,
+      "name": null,
+      "type": "switch",
+      "enable": true,
+      "invert": false,
+      "factory_reset": true
+    },
+    "input:2": {
+      "id": 2,
+      "name": null,
+      "type": "switch",
+      "enable": true,
+      "invert": false,
+      "factory_reset": true
+    },
+    "input:3": {
+      "id": 3,
+      "name": null,
+      "type": "switch",
+      "enable": true,
+      "invert": false,
+      "factory_reset": true
+    },
+    "knx": {
+      "enable": false,
+      "ia": "15.15.255",
+      "routing": {
+        "addr": "224.0.23.12:3671"
+      }
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shellyi4g3-5432045661b4",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shellyi4g3-5432045661b4",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "sys": {
+      "device": {
+        "name": "My Shelly i4 Gen3",
+        "mac": "5432045661B4",
+        "fw_id": "20240819-074305/1.4.2-gc2639da",
+        "discoverable": true,
+        "eco_mode": false,
+        "addon_type": null
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 13
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "ShellyI4G3-5432045661B4",
+        "is_open": true,
+        "enable": false,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {
+      "errors": [
+        "bluetooth_disabled"
+      ]
+    },
+    "cloud": {
+      "connected": true
+    },
+    "input:0": {
+      "id": 0,
+      "state": false
+    },
+    "input:1": {
+      "id": 1,
+      "state": false
+    },
+    "input:2": {
+      "id": 2,
+      "state": false
+    },
+    "input:3": {
+      "id": 3,
+      "state": false
+    },
+    "knx": {},
+    "mqtt": {
+      "connected": false
+    },
+    "sys": {
+      "mac": "5432045661B4",
+      "restart_required": false,
+      "time": "23:57",
+      "unixtime": 1725746265,
+      "uptime": 252,
+      "ram_size": 259824,
+      "ram_free": 133164,
+      "fs_size": 1048576,
+      "fs_free": 593920,
+      "cfg_rev": 13,
+      "kvs_rev": 0,
+      "schedule_rev": 0,
+      "webhook_rev": 0,
+      "available_updates": {},
+      "reset_reason": 3
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.159",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -54
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": false,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": false
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {
+        "errors": [
+          "bluetooth_disabled"
+        ]
+      },
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": true
+      },
+      "config": {
+        "enable": true,
+        "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+      }
+    },
+    {
+      "key": "input:0",
+      "status": {
+        "id": 0,
+        "state": false
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "type": "switch",
+        "enable": true,
+        "invert": false,
+        "factory_reset": true
+      }
+    },
+    {
+      "key": "input:1",
+      "status": {
+        "id": 1,
+        "state": false
+      },
+      "config": {
+        "id": 1,
+        "name": null,
+        "type": "switch",
+        "enable": true,
+        "invert": false,
+        "factory_reset": true
+      }
+    },
+    {
+      "key": "input:2",
+      "status": {
+        "id": 2,
+        "state": false
+      },
+      "config": {
+        "id": 2,
+        "name": null,
+        "type": "switch",
+        "enable": true,
+        "invert": false,
+        "factory_reset": true
+      }
+    },
+    {
+      "key": "input:3",
+      "status": {
+        "id": 3,
+        "state": false
+      },
+      "config": {
+        "id": 3,
+        "name": null,
+        "type": "switch",
+        "enable": true,
+        "invert": false,
+        "factory_reset": true
+      }
+    },
+    {
+      "key": "knx",
+      "status": {},
+      "config": {
+        "enable": false,
+        "ia": "15.15.255",
+        "routing": {
+          "addr": "224.0.23.12:3671"
+        }
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shellyi4g3-5432045661b4",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shellyi4g3-5432045661b4",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "5432045661B4",
+        "restart_required": false,
+        "time": "23:57",
+        "unixtime": 1725746266,
+        "uptime": 252,
+        "ram_size": 259816,
+        "ram_free": 131616,
+        "fs_size": 1048576,
+        "fs_free": 593920,
+        "cfg_rev": 13,
+        "kvs_rev": 0,
+        "schedule_rev": 0,
+        "webhook_rev": 0,
+        "available_updates": {},
+        "reset_reason": 3
+      },
+      "config": {
+        "device": {
+          "name": "My Shelly i4 Gen3",
+          "mac": "5432045661B4",
+          "fw_id": "20240819-074305/1.4.2-gc2639da",
+          "discoverable": true,
+          "eco_mode": false,
+          "addon_type": null
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7314,
+          "lon": 7.419
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 13
+      }
+    }
+  ]
+}

--- a/src/mock/shellyi4g3-5432045661B4.mdns.json
+++ b/src/mock/shellyi4g3-5432045661B4.mdns.json
@@ -1,0 +1,117 @@
+{
+  "id": 0,
+  "type": "response",
+  "flags": 1024,
+  "flag_qr": true,
+  "opcode": "QUERY",
+  "flag_aa": true,
+  "flag_tc": false,
+  "flag_rd": false,
+  "flag_ra": false,
+  "flag_z": false,
+  "flag_ad": false,
+  "flag_cd": false,
+  "rcode": "NOERROR",
+  "questions": [],
+  "answers": [
+    {
+      "name": "_http._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shellyi4g3-5432045661b4._http._tcp.local"
+    },
+    {
+      "name": "_shelly._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shellyi4g3-5432045661b4._shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_http._tcp.local"
+    }
+  ],
+  "authorities": [],
+  "additionals": [
+    {
+      "name": "shellyi4g3-5432045661b4._http._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "ShellyI4G3-5432045661B4.local"
+      }
+    },
+    {
+      "name": "shellyi4g3-5432045661b4._http._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=3"
+      ]
+    },
+    {
+      "name": "ShellyI4G3-5432045661B4.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.159"
+    },
+    {
+      "name": "shellyi4g3-5432045661b4._shelly._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "ShellyI4G3-5432045661B4.local"
+      }
+    },
+    {
+      "name": "shellyi4g3-5432045661b4._shelly._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=3",
+        "app=I4G3",
+        "ver=1.4.2"
+      ]
+    },
+    {
+      "name": "ShellyI4G3-5432045661B4.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.159"
+    }
+  ]
+}

--- a/src/mock/shellymotion2-8CF68108A6F5.mdns.json
+++ b/src/mock/shellymotion2-8CF68108A6F5.mdns.json
@@ -65,7 +65,11 @@
       "ttl": 3600,
       "class": "IN",
       "flush": true,
-      "data": ["fw_id=20240619-130804/v2.2.4@ee290818", "id=shellymotion2-8CF68108A6F5", "arch=EFM32GG11"]
+      "data": [
+        "fw_id=20240619-130804/v2.2.4@ee290818",
+        "id=shellymotion2-8CF68108A6F5",
+        "arch=EFM32GG11"
+      ]
     }
   ],
   "authorities": [],

--- a/src/mock/shellymotionsensor-60A42386E566.mdns.json
+++ b/src/mock/shellymotionsensor-60A42386E566.mdns.json
@@ -65,7 +65,11 @@
       "ttl": 3600,
       "class": "IN",
       "flush": true,
-      "data": ["fw_id=20240619-130804/v2.2.4@ee290818", "id=shellymotionsensor-60A42386E566", "arch=EFM32GG11"]
+      "data": [
+        "fw_id=20240619-130804/v2.2.4@ee290818",
+        "id=shellymotionsensor-60A42386E566",
+        "arch=EFM32GG11"
+      ]
     }
   ],
   "authorities": [],

--- a/src/mock/shellyprodm1pm-34987A4957C4.json
+++ b/src/mock/shellyprodm1pm-34987A4957C4.json
@@ -1,0 +1,449 @@
+{
+  "shelly": {
+    "name": "My Shelly Dimmer 1PM PRO",
+    "id": "shellyprodm1pm-34987a4957c4",
+    "mac": "34987A4957C4",
+    "slot": 1,
+    "model": "SPDM-001PE01EU",
+    "gen": 2,
+    "fw_id": "20240819-074552/1.4.2-gc2639da",
+    "ver": "1.4.2",
+    "app": "ProDimmerx",
+    "auth_en": false,
+    "auth_domain": null
+  },
+  "settings": {
+    "ble": {
+      "enable": true,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": true
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": true,
+      "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+    },
+    "eth": {
+      "enable": true,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "input:0": {
+      "id": 0,
+      "name": null,
+      "type": "button",
+      "enable": true,
+      "invert": false
+    },
+    "input:1": {
+      "id": 1,
+      "name": null,
+      "type": "button",
+      "enable": true,
+      "invert": false
+    },
+    "knx": {
+      "enable": false,
+      "ia": "15.15.255",
+      "routing": {
+        "addr": "224.0.23.12:3671"
+      }
+    },
+    "light:0": {
+      "id": 0,
+      "name": null,
+      "initial_state": "restore_last",
+      "auto_on": false,
+      "auto_on_delay": 60,
+      "auto_off": false,
+      "auto_off_delay": 60,
+      "transition_duration": 3,
+      "min_brightness_on_toggle": 3,
+      "night_mode": {
+        "enable": false,
+        "brightness": 50,
+        "active_between": []
+      },
+      "button_fade_rate": 3,
+      "button_presets": {
+        "button_doublepush": {
+          "brightness": 100
+        }
+      },
+      "in_mode": "dim",
+      "current_limit": 1.22,
+      "power_limit": 230,
+      "undervoltage_limit": 200,
+      "voltage_limit": 280
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shellyprodm1pm-34987a4957c4",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shellyprodm1pm-34987a4957c4",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "sys": {
+      "device": {
+        "name": "My Shelly Dimmer 1PM PRO",
+        "mac": "34987A4957C4",
+        "fw_id": "20240819-074552/1.4.2-gc2639da",
+        "discoverable": true
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 14
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "ShellyProDM1PM-34987A4957C4",
+        "is_open": true,
+        "enable": false,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {},
+    "cloud": {
+      "connected": true
+    },
+    "eth": {
+      "ip": null
+    },
+    "input:0": {
+      "id": 0,
+      "state": null
+    },
+    "input:1": {
+      "id": 1,
+      "state": null
+    },
+    "knx": {},
+    "light:0": {
+      "id": 0,
+      "source": "WS_in",
+      "output": true,
+      "brightness": 2,
+      "temperature": {
+        "tC": 33.1,
+        "tF": 91.6
+      },
+      "aenergy": {
+        "total": 0.006,
+        "by_minute": [
+          0,
+          0,
+          0
+        ],
+        "minute_ts": 1725723900
+      },
+      "apower": 1,
+      "current": 0.017,
+      "voltage": 232.8
+    },
+    "mqtt": {
+      "connected": false
+    },
+    "sys": {
+      "mac": "34987A4957C4",
+      "restart_required": false,
+      "time": "17:45",
+      "unixtime": 1725723943,
+      "uptime": 247,
+      "ram_size": 265768,
+      "ram_free": 83868,
+      "fs_size": 524288,
+      "fs_free": 184320,
+      "cfg_rev": 14,
+      "kvs_rev": 0,
+      "schedule_rev": 1,
+      "webhook_rev": 0,
+      "available_updates": {},
+      "reset_reason": 1
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.156",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -61
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": true,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": true
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {},
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": true
+      },
+      "config": {
+        "enable": true,
+        "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+      }
+    },
+    {
+      "key": "eth",
+      "status": {
+        "ip": null
+      },
+      "config": {
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      }
+    },
+    {
+      "key": "input:0",
+      "status": {
+        "id": 0,
+        "state": null
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "type": "button",
+        "enable": true,
+        "invert": false
+      }
+    },
+    {
+      "key": "input:1",
+      "status": {
+        "id": 1,
+        "state": null
+      },
+      "config": {
+        "id": 1,
+        "name": null,
+        "type": "button",
+        "enable": true,
+        "invert": false
+      }
+    },
+    {
+      "key": "knx",
+      "status": {},
+      "config": {
+        "enable": false,
+        "ia": "15.15.255",
+        "routing": {
+          "addr": "224.0.23.12:3671"
+        }
+      }
+    },
+    {
+      "key": "light:0",
+      "status": {
+        "id": 0,
+        "source": "WS_in",
+        "output": true,
+        "brightness": 2,
+        "temperature": {
+          "tC": 33,
+          "tF": 91.4
+        },
+        "aenergy": {
+          "total": 0.007,
+          "by_minute": [
+            0,
+            0,
+            0
+          ],
+          "minute_ts": 1725723900
+        },
+        "apower": 1,
+        "current": 0.017,
+        "voltage": 232.7
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "initial_state": "restore_last",
+        "auto_on": false,
+        "auto_on_delay": 60,
+        "auto_off": false,
+        "auto_off_delay": 60,
+        "transition_duration": 3,
+        "min_brightness_on_toggle": 3,
+        "night_mode": {
+          "enable": false,
+          "brightness": 50,
+          "active_between": []
+        },
+        "button_fade_rate": 3,
+        "button_presets": {
+          "button_doublepush": {
+            "brightness": 100
+          }
+        },
+        "in_mode": "dim",
+        "current_limit": 1.22,
+        "power_limit": 230,
+        "undervoltage_limit": 200,
+        "voltage_limit": 280
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shellyprodm1pm-34987a4957c4",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shellyprodm1pm-34987a4957c4",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "34987A4957C4",
+        "restart_required": false,
+        "time": "17:45",
+        "unixtime": 1725723944,
+        "uptime": 248,
+        "ram_size": 265748,
+        "ram_free": 82020,
+        "fs_size": 524288,
+        "fs_free": 184320,
+        "cfg_rev": 14,
+        "kvs_rev": 0,
+        "schedule_rev": 1,
+        "webhook_rev": 0,
+        "available_updates": {},
+        "reset_reason": 1
+      },
+      "config": {
+        "device": {
+          "name": "My Shelly Dimmer 1PM PRO",
+          "mac": "34987A4957C4",
+          "fw_id": "20240819-074552/1.4.2-gc2639da",
+          "discoverable": true
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7314,
+          "lon": 7.419
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 14
+      }
+    }
+  ]
+}

--- a/src/mock/shellyprodm1pm-34987A4957C4.mdns.json
+++ b/src/mock/shellyprodm1pm-34987A4957C4.mdns.json
@@ -1,0 +1,117 @@
+{
+  "id": 0,
+  "type": "response",
+  "flags": 1024,
+  "flag_qr": true,
+  "opcode": "QUERY",
+  "flag_aa": true,
+  "flag_tc": false,
+  "flag_rd": false,
+  "flag_ra": false,
+  "flag_z": false,
+  "flag_ad": false,
+  "flag_cd": false,
+  "rcode": "NOERROR",
+  "questions": [],
+  "answers": [
+    {
+      "name": "_http._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shellyprodm1pm-34987a4957c4._http._tcp.local"
+    },
+    {
+      "name": "_shelly._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "shellyprodm1pm-34987a4957c4._shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_shelly._tcp.local"
+    },
+    {
+      "name": "_services._dns-sd._udp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "_http._tcp.local"
+    }
+  ],
+  "authorities": [],
+  "additionals": [
+    {
+      "name": "shellyprodm1pm-34987a4957c4._http._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "ShellyProDM1PM-34987A4957C4.local"
+      }
+    },
+    {
+      "name": "shellyprodm1pm-34987a4957c4._http._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=2"
+      ]
+    },
+    {
+      "name": "ShellyProDM1PM-34987A4957C4.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.156"
+    },
+    {
+      "name": "shellyprodm1pm-34987a4957c4._shelly._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "ShellyProDM1PM-34987A4957C4.local"
+      }
+    },
+    {
+      "name": "shellyprodm1pm-34987a4957c4._shelly._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=2",
+        "app=ProDimmerx",
+        "ver=1.4.2"
+      ]
+    },
+    {
+      "name": "ShellyProDM1PM-34987A4957C4.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.1.156"
+    }
+  ]
+}

--- a/src/mock/shellyprodm1pm-34987A4957C4.notcalibrated.json
+++ b/src/mock/shellyprodm1pm-34987A4957C4.notcalibrated.json
@@ -1,0 +1,455 @@
+{
+  "shelly": {
+    "name": "My Shelly Dimmer 1PM PRO",
+    "id": "shellyprodm1pm-34987a4957c4",
+    "mac": "34987A4957C4",
+    "slot": 1,
+    "model": "SPDM-001PE01EU",
+    "gen": 2,
+    "fw_id": "20240819-074552/1.4.2-gc2639da",
+    "ver": "1.4.2",
+    "app": "ProDimmerx",
+    "auth_en": false,
+    "auth_domain": null
+  },
+  "settings": {
+    "ble": {
+      "enable": true,
+      "rpc": {
+        "enable": true
+      },
+      "observer": {
+        "enable": true
+      }
+    },
+    "bthome": {},
+    "cloud": {
+      "enable": true,
+      "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+    },
+    "eth": {
+      "enable": true,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "input:0": {
+      "id": 0,
+      "name": null,
+      "type": "button",
+      "enable": true,
+      "invert": false
+    },
+    "input:1": {
+      "id": 1,
+      "name": null,
+      "type": "button",
+      "enable": true,
+      "invert": false
+    },
+    "knx": {
+      "enable": false,
+      "ia": "15.15.255",
+      "routing": {
+        "addr": "224.0.23.12:3671"
+      }
+    },
+    "light:0": {
+      "id": 0,
+      "name": null,
+      "initial_state": "restore_last",
+      "auto_on": false,
+      "auto_on_delay": 60,
+      "auto_off": false,
+      "auto_off_delay": 60,
+      "transition_duration": 3,
+      "min_brightness_on_toggle": 3,
+      "night_mode": {
+        "enable": false,
+        "brightness": 50,
+        "active_between": []
+      },
+      "button_fade_rate": 3,
+      "button_presets": {
+        "button_doublepush": {
+          "brightness": 100
+        }
+      },
+      "in_mode": "dim",
+      "current_limit": 1.22,
+      "power_limit": 230,
+      "undervoltage_limit": 200,
+      "voltage_limit": 280
+    },
+    "mqtt": {
+      "enable": false,
+      "server": null,
+      "client_id": "shellyprodm1pm-34987a4957c4",
+      "user": null,
+      "ssl_ca": null,
+      "topic_prefix": "shellyprodm1pm-34987a4957c4",
+      "rpc_ntf": true,
+      "status_ntf": false,
+      "use_client_cert": false,
+      "enable_rpc": true,
+      "enable_control": true
+    },
+    "sys": {
+      "device": {
+        "name": "My Shelly Dimmer 1PM PRO",
+        "mac": "34987A4957C4",
+        "fw_id": "20240819-074552/1.4.2-gc2639da",
+        "discoverable": true
+      },
+      "location": null,
+      "debug": {
+        "level": 2,
+        "file_level": null,
+        "mqtt": {
+          "enable": false
+        },
+        "websocket": {
+          "enable": false
+        },
+        "udp": {
+          "addr": null
+        }
+      },
+      "ui_data": {},
+      "rpc_udp": {
+        "dst_addr": null,
+        "listen_port": null
+      },
+      "sntp": {
+        "server": "time.google.com"
+      },
+      "cfg_rev": 14
+    },
+    "wifi": {
+      "ap": {
+        "ssid": "ShellyProDM1PM-34987A4957C4",
+        "is_open": true,
+        "enable": false,
+        "range_extender": {
+          "enable": false
+        }
+      },
+      "sta": {
+        "ssid": "FibreBox_X6-12A4C7",
+        "is_open": false,
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "sta1": {
+        "ssid": null,
+        "is_open": true,
+        "enable": false,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      },
+      "roam": {
+        "rssi_thr": -80,
+        "interval": 60
+      }
+    },
+    "ws": {
+      "enable": false,
+      "server": null,
+      "ssl_ca": "ca.pem"
+    }
+  },
+  "status": {
+    "ble": {},
+    "bthome": {},
+    "cloud": {
+      "connected": true
+    },
+    "eth": {
+      "ip": null
+    },
+    "input:0": {
+      "id": 0,
+      "state": null
+    },
+    "input:1": {
+      "id": 1,
+      "state": null
+    },
+    "knx": {},
+    "light:0": {
+      "id": 0,
+      "source": "",
+      "output": false,
+      "brightness": 1,
+      "temperature": {
+        "tC": 34.7,
+        "tF": 94.4
+      },
+      "aenergy": {
+        "total": 0,
+        "by_minute": [
+          0,
+          0,
+          0
+        ],
+        "minute_ts": 1725717900
+      },
+      "apower": 0,
+      "current": 0,
+      "voltage": 232.8,
+      "flags": [
+        "uncalibrated"
+      ]
+    },
+    "mqtt": {
+      "connected": false
+    },
+    "sys": {
+      "mac": "34987A4957C4",
+      "restart_required": false,
+      "time": "16:05",
+      "unixtime": 1725717918,
+      "uptime": 439,
+      "ram_size": 265792,
+      "ram_free": 85660,
+      "fs_size": 524288,
+      "fs_free": 188416,
+      "cfg_rev": 14,
+      "kvs_rev": 0,
+      "schedule_rev": 1,
+      "webhook_rev": 0,
+      "available_updates": {},
+      "reset_reason": 3
+    },
+    "wifi": {
+      "sta_ip": "192.168.1.156",
+      "status": "got ip",
+      "ssid": "FibreBox_X6-12A4C7",
+      "rssi": -65
+    },
+    "ws": {
+      "connected": false
+    }
+  },
+  "components": [
+    {
+      "key": "ble",
+      "status": {},
+      "config": {
+        "enable": true,
+        "rpc": {
+          "enable": true
+        },
+        "observer": {
+          "enable": true
+        }
+      }
+    },
+    {
+      "key": "bthome",
+      "status": {},
+      "config": {}
+    },
+    {
+      "key": "cloud",
+      "status": {
+        "connected": true
+      },
+      "config": {
+        "enable": true,
+        "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
+      }
+    },
+    {
+      "key": "eth",
+      "status": {
+        "ip": null
+      },
+      "config": {
+        "enable": true,
+        "ipv4mode": "dhcp",
+        "ip": null,
+        "netmask": null,
+        "gw": null,
+        "nameserver": null
+      }
+    },
+    {
+      "key": "input:0",
+      "status": {
+        "id": 0,
+        "state": null
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "type": "button",
+        "enable": true,
+        "invert": false
+      }
+    },
+    {
+      "key": "input:1",
+      "status": {
+        "id": 1,
+        "state": null
+      },
+      "config": {
+        "id": 1,
+        "name": null,
+        "type": "button",
+        "enable": true,
+        "invert": false
+      }
+    },
+    {
+      "key": "knx",
+      "status": {},
+      "config": {
+        "enable": false,
+        "ia": "15.15.255",
+        "routing": {
+          "addr": "224.0.23.12:3671"
+        }
+      }
+    },
+    {
+      "key": "light:0",
+      "status": {
+        "id": 0,
+        "source": "",
+        "output": false,
+        "brightness": 1,
+        "temperature": {
+          "tC": 34.6,
+          "tF": 94.3
+        },
+        "aenergy": {
+          "total": 0,
+          "by_minute": [
+            0,
+            0,
+            0
+          ],
+          "minute_ts": 1725717900
+        },
+        "apower": 0,
+        "current": 0,
+        "voltage": 232.9,
+        "flags": [
+          "uncalibrated"
+        ]
+      },
+      "config": {
+        "id": 0,
+        "name": null,
+        "initial_state": "restore_last",
+        "auto_on": false,
+        "auto_on_delay": 60,
+        "auto_off": false,
+        "auto_off_delay": 60,
+        "transition_duration": 3,
+        "min_brightness_on_toggle": 3,
+        "night_mode": {
+          "enable": false,
+          "brightness": 50,
+          "active_between": []
+        },
+        "button_fade_rate": 3,
+        "button_presets": {
+          "button_doublepush": {
+            "brightness": 100
+          }
+        },
+        "in_mode": "dim",
+        "current_limit": 1.22,
+        "power_limit": 230,
+        "undervoltage_limit": 200,
+        "voltage_limit": 280
+      }
+    },
+    {
+      "key": "mqtt",
+      "status": {
+        "connected": false
+      },
+      "config": {
+        "enable": false,
+        "server": null,
+        "client_id": "shellyprodm1pm-34987a4957c4",
+        "user": null,
+        "ssl_ca": null,
+        "topic_prefix": "shellyprodm1pm-34987a4957c4",
+        "rpc_ntf": true,
+        "status_ntf": false,
+        "use_client_cert": false,
+        "enable_rpc": true,
+        "enable_control": true
+      }
+    },
+    {
+      "key": "sys",
+      "status": {
+        "mac": "34987A4957C4",
+        "restart_required": false,
+        "time": "16:05",
+        "unixtime": 1725717918,
+        "uptime": 439,
+        "ram_size": 265780,
+        "ram_free": 84072,
+        "fs_size": 524288,
+        "fs_free": 188416,
+        "cfg_rev": 14,
+        "kvs_rev": 0,
+        "schedule_rev": 1,
+        "webhook_rev": 0,
+        "available_updates": {},
+        "reset_reason": 3
+      },
+      "config": {
+        "device": {
+          "name": "My Shelly Dimmer 1PM PRO",
+          "mac": "34987A4957C4",
+          "fw_id": "20240819-074552/1.4.2-gc2639da",
+          "discoverable": true
+        },
+        "location": {
+          "tz": "Europe/Monaco",
+          "lat": 43.7314,
+          "lon": 7.419
+        },
+        "debug": {
+          "level": 2,
+          "file_level": null,
+          "mqtt": {
+            "enable": false
+          },
+          "websocket": {
+            "enable": false
+          },
+          "udp": {
+            "addr": null
+          }
+        },
+        "ui_data": {},
+        "rpc_udp": {
+          "dst_addr": null,
+          "listen_port": null
+        },
+        "sntp": {
+          "server": "time.google.com"
+        },
+        "cfg_rev": 14
+      }
+    }
+  ]
+}

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -37,6 +37,7 @@ describe('ShellyPlatform', () => {
       matterbridgeDirectory: '',
       matterbridgePluginDirectory: 'temp',
       systemInformation: { ipv4Address: undefined },
+      matterbridgeVersion: '1.5.4',
       removeAllBridgedDevices: jest.fn(),
     } as unknown as Matterbridge;
     mockLog = {
@@ -230,6 +231,18 @@ describe('ShellyPlatform', () => {
     expect(isValidUndefined(undefined)).toBe(true);
     expect(isValidUndefined({ x: 1, y: 4 })).toBe(false);
     expect(isValidUndefined([1, 4, 'string'])).toBe(false);
+  });
+
+  it('should validate version', () => {
+    mockMatterbridge.matterbridgeVersion = '1.5.4';
+    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.3')).toBe(true);
+    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.4')).toBe(true);
+    expect(shellyPlatform.verifyMatterbridgeVersion('2.0.0')).toBe(false);
+
+    mockMatterbridge.matterbridgeVersion = '1.5.4-dev.1';
+    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.3')).toBe(true);
+    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.4')).toBe(true);
+    expect(shellyPlatform.verifyMatterbridgeVersion('2.0.0')).toBe(false);
   });
 
   it('should call onStart with reason', async () => {

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -235,14 +235,16 @@ describe('ShellyPlatform', () => {
 
   it('should validate version', () => {
     mockMatterbridge.matterbridgeVersion = '1.5.4';
-    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.3')).toBe(true);
-    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.4')).toBe(true);
-    expect(shellyPlatform.verifyMatterbridgeVersion('2.0.0')).toBe(false);
+    expect(shellyPlatform.localVerifyMatterbridgeVersion('1.5.3')).toBe(true);
+    expect(shellyPlatform.localVerifyMatterbridgeVersion('1.5.4')).toBe(true);
+    expect(shellyPlatform.localVerifyMatterbridgeVersion('2.0.0')).toBe(false);
+  });
 
+  it('should validate version beta', () => {
     mockMatterbridge.matterbridgeVersion = '1.5.4-dev.1';
-    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.3')).toBe(true);
-    expect(shellyPlatform.verifyMatterbridgeVersion('1.5.4')).toBe(true);
-    expect(shellyPlatform.verifyMatterbridgeVersion('2.0.0')).toBe(false);
+    expect(shellyPlatform.localVerifyMatterbridgeVersion('1.5.3')).toBe(true);
+    expect(shellyPlatform.localVerifyMatterbridgeVersion('1.5.4')).toBe(true);
+    expect(shellyPlatform.localVerifyMatterbridgeVersion('2.0.0')).toBe(false);
   });
 
   it('should call onStart with reason', async () => {

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -2,11 +2,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Matterbridge, MatterbridgeDevice, PlatformConfig } from 'matterbridge';
-import { wait } from 'matterbridge/utils';
 import { AnsiLogger, db, idn, LogLevel, nf, rs } from 'matterbridge/logger';
-import { ShellyPlatform } from './platform';
-import { isValidArray, isValidBoolean, isValidNull, isValidNumber, isValidObject, isValidString, isValidUndefined } from 'matterbridge/utils';
+import { isValidArray, isValidBoolean, isValidNull, isValidNumber, isValidObject, isValidString, isValidUndefined, wait } from 'matterbridge/utils';
 import { jest } from '@jest/globals';
+
+import { ShellyPlatform } from './platform';
 
 describe('ShellyPlatform', () => {
   let mockMatterbridge: Matterbridge;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -903,7 +903,10 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
 
   localVerifyMatterbridgeVersion(version: string): boolean {
     const compareVersions = (matterbridgeVersion: string, requiredVersion: string): boolean => {
-      const stripTag = (v: string) => v.split('-')[0];
+      const stripTag = (v: string) => {
+        const parts = v.split('-');
+        return parts.length > 0 ? parts[0] : v;
+      };
       const v1Parts = stripTag(matterbridgeVersion).split('.').map(Number);
       const v2Parts = stripTag(requiredVersion).split('.').map(Number);
       for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -814,11 +814,12 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
 
     // Wait for the failsafe count
     if (this.failsafeCount > 0) {
-      this.log.notice(`Waiting for the configured number of ${this.failsafeCount} devices to be loaded`);
-      const isSafe = await waiter('failsafeCount', () => this.shellyDevices.size + this.bluBridgedDevices.size >= this.failsafeCount, false, 60000, 1000);
+      const registered = this.shellyDevices.size + this.bluBridgedDevices.size;
+      this.log.notice(`Waiting for the configured number of ${this.failsafeCount} devices to be loaded: ${registered} devices loaded.`);
+      const isSafe = await waiter('failsafeCount', () => registered >= this.failsafeCount, false, 60000, 1000);
       if (!isSafe) {
-        this.log.error(`The plugin did not reach the configured number of ${this.failsafeCount} devices. Registered ${this.shellyDevices.size} devices.`);
-        throw new Error(`The plugin did not reach the configured number of ${this.failsafeCount} devices. Registered ${this.shellyDevices.size} devices.`);
+        this.log.error(`The plugin did not add the configured number of ${this.failsafeCount} devices. Registered ${registered} devices.`);
+        throw new Error(`The plugin did not add the configured number of ${this.failsafeCount} devices. Registered ${registered} devices.`);
       }
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -56,7 +56,6 @@ import {
   ElectricalPowerMeasurement,
   ElectricalEnergyMeasurement,
 } from 'matterbridge';
-import {} from 'matterbridge/cluster';
 
 import { EveHistory, EveHistoryCluster, MatterHistory } from 'matterbridge/history';
 import { AnsiLogger, BLUE, CYAN, GREEN, LogLevel, TimestampFormat, YELLOW, db, debugStringify, dn, er, hk, idn, nf, or, rs, wr, zb } from 'matterbridge/logger';

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -102,7 +102,7 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
     super(matterbridge, log, config);
 
     // Verify that Matterbridge is the correct version
-    if (!this.verifyMatterbridgeVersion('1.5.4')) {
+    if (!this.localVerifyMatterbridgeVersion('1.5.4')) {
       throw new Error(`The shelly plugin requires Matterbridge version >= "1.5.4". Please update Matterbridge to the latest version in the frontend."`);
     }
 
@@ -901,7 +901,7 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
     this.shelly.setLogLevel(logLevel, this.config.debugMdns as boolean, this.config.debugCoap as boolean, this.config.debugWs as boolean);
   }
 
-  verifyMatterbridgeVersion(version: string): boolean {
+  localVerifyMatterbridgeVersion(version: string): boolean {
     const compareVersions = (matterbridgeVersion: string, requiredVersion: string): boolean => {
       const stripTag = (v: string) => v.split('-')[0];
       const v1Parts = stripTag(matterbridgeVersion).split('.').map(Number);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -918,12 +918,7 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
       return true;
     };
 
-    if (!compareVersions(this.matterbridge.matterbridgeVersion, version)) {
-      this.log.error(
-        `This plugin requires Matterbridge version >= ${version}. Current Matterbridge version ${this.matterbridge.matterbridgeVersion} is less than required version ${version}`,
-      );
-      return false;
-    }
+    if (!compareVersions(this.matterbridge.matterbridgeVersion, version)) return false;
     return true;
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -817,6 +817,7 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
       this.log.notice(`Waiting for the configured number of ${this.failsafeCount} devices to be loaded`);
       const isSafe = await waiter('failsafeCount', () => this.shellyDevices.size + this.bluBridgedDevices.size >= this.failsafeCount, false, 60000, 1000);
       if (!isSafe) {
+        this.log.error(`The plugin did not reach the configured number of ${this.failsafeCount} devices. Registered ${this.shellyDevices.size} devices.`);
         throw new Error(`The plugin did not reach the configured number of ${this.failsafeCount} devices. Registered ${this.shellyDevices.size} devices.`);
       }
     }

--- a/src/shellyDevice.mock.test.ts
+++ b/src/shellyDevice.mock.test.ts
@@ -1279,6 +1279,98 @@ describe('Shelly devices test', () => {
       if (device) device.destroy();
     });
 
+    test('Create a gen 3 shelly1g3 device', async () => {
+      id = 'shelly1g3-34B7DACAC830';
+      log.logName = id;
+
+      device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+      expect(device).not.toBeUndefined();
+      if (!device) return;
+      expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+      expect(device.model).toBe('S3SW-001X16EU');
+      expect(device.mac).toBe('34B7DACAC830');
+      expect(device.id).toBe(id);
+      expect(device.firmware).toBe('1.4.2-gc2639da'); // firmwareGen2
+      expect(device.auth).toBe(false);
+      expect(device.gen).toBe(3);
+      expect(device.profile).toBe(undefined);
+      expect(device.name).toBe('My Shelly 1 Gen3');
+      expect(device.hasUpdate).toBe(false);
+      expect(device.lastseen).not.toBe(0);
+      expect(device.online).toBe(true);
+      expect(device.cached).toBe(false);
+      expect(device.sleepMode).toBe(false);
+
+      expect(device.components.length).toBe(11);
+      expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'MQTT', 'Switch', 'Sys', 'Sntp', 'WiFi', 'WS']);
+      expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'mqtt', 'switch:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+      expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+      expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+      expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+
+      expect(device.getComponent('switch:0')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('switch:0')?.hasProperty('brightness')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('rgb')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('red')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('green')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('blu')).toBe(false);
+
+      expect(await device.fetchUpdate()).not.toBeNull();
+
+      if (device) device.destroy();
+    });
+
+    test('Create a gen 3 shelly1pmg3 device', async () => {
+      id = 'shelly1pmg3-34B7DAC68344';
+      log.logName = id;
+
+      device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+      expect(device).not.toBeUndefined();
+      if (!device) return;
+      expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+      expect(device.model).toBe('S3SW-001P16EU');
+      expect(device.mac).toBe('34B7DAC68344');
+      expect(device.id).toBe(id);
+      expect(device.firmware).toBe('1.4.2-gc2639da'); // firmwareGen2
+      expect(device.auth).toBe(false);
+      expect(device.gen).toBe(3);
+      expect(device.profile).toBe(undefined);
+      expect(device.name).toBe('My Shelly 1PM Gen3');
+      expect(device.hasUpdate).toBe(false);
+      expect(device.lastseen).not.toBe(0);
+      expect(device.online).toBe(true);
+      expect(device.cached).toBe(false);
+      expect(device.sleepMode).toBe(false);
+
+      expect(device.components.length).toBe(11);
+      expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'MQTT', 'Switch', 'Sys', 'Sntp', 'WiFi', 'WS']);
+      expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'mqtt', 'switch:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+      expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+      expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+      expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+
+      expect(device.getComponent('switch:0')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('switch:0')?.hasProperty('brightness')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('rgb')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('red')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('green')).toBe(false);
+      expect(device.getComponent('switch:0')?.hasProperty('blu')).toBe(false);
+
+      expect(device.getComponent('switch:0')?.hasProperty('voltage')).toBe(true);
+      expect(device.getComponent('switch:0')?.hasProperty('current')).toBe(true);
+      expect(device.getComponent('switch:0')?.hasProperty('apower')).toBe(true);
+      expect(device.getComponent('switch:0')?.hasProperty('aenergy')).toBe(true);
+      expect((device.getComponent('switch:0')?.getValue('aenergy') as ShellyData).total).toBeGreaterThanOrEqual(0);
+
+      expect(await device.fetchUpdate()).not.toBeNull();
+
+      if (device) device.destroy();
+    });
+
     test('Create a gen 3 shelly0110dimg3 device', async () => {
       id = 'shelly0110dimg3-34B7DA902E24';
       log.logName = id;

--- a/src/shellyDevice.mock.test.ts
+++ b/src/shellyDevice.mock.test.ts
@@ -1371,6 +1371,45 @@ describe('Shelly devices test', () => {
       if (device) device.destroy();
     });
 
+    test('Create a gen 3 shellyi4g3 device', async () => {
+      id = 'shellyi4g3-5432045661B4';
+      log.logName = id;
+
+      device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+      expect(device).not.toBeUndefined();
+      if (!device) return;
+      expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+      expect(device.model).toBe('S3SN-0024X');
+      expect(device.mac).toBe('5432045661B4');
+      expect(device.id).toBe(id);
+      expect(device.firmware).toBe('1.4.2-gc2639da'); // firmwareGen2
+      expect(device.auth).toBe(false);
+      expect(device.gen).toBe(3);
+      expect(device.profile).toBe(undefined);
+      expect(device.name).toBe('My Shelly i4 Gen3');
+      expect(device.hasUpdate).toBe(false);
+      expect(device.lastseen).not.toBe(0);
+      expect(device.online).toBe(true);
+      expect(device.cached).toBe(false);
+      expect(device.sleepMode).toBe(false);
+
+      expect(device.components.length).toBe(13);
+      expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'MQTT', 'Sys', 'Sntp', 'WiFi', 'WS']);
+      expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'input:1', 'input:2', 'input:3', 'mqtt', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+      expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+      expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+      expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('input:1')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('input:2')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('input:3')?.hasProperty('state')).toBe(true);
+
+      expect(await device.fetchUpdate()).not.toBeNull();
+
+      if (device) device.destroy();
+    });
+
     test('Create a gen 3 shelly0110dimg3 device', async () => {
       id = 'shelly0110dimg3-34B7DA902E24';
       log.logName = id;

--- a/src/shellyDevice.mock.test.ts
+++ b/src/shellyDevice.mock.test.ts
@@ -1575,5 +1575,51 @@ describe('Shelly devices test', () => {
 
       if (device) device.destroy();
     });
+
+    test('Create a pro shellyprodm1pm device', async () => {
+      id = 'shellyprodm1pm-34987A4957C4';
+      log.logName = id;
+
+      device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+      expect(device).not.toBeUndefined();
+      if (!device) return;
+      expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+      expect(device.model).toBe('SPDM-001PE01EU');
+      expect(device.mac).toBe('34987A4957C4');
+      expect(device.id).toBe(id);
+      expect(device.firmware).toBe('1.4.2-gc2639da'); // firmwareGen2
+      expect(device.auth).toBe(false);
+      expect(device.gen).toBe(2);
+      expect(device.profile).toBe(undefined);
+      expect(device.name).toBe('My Shelly Dimmer 1PM PRO');
+      expect(device.hasUpdate).toBe(false);
+      expect(device.lastseen).not.toBe(0);
+      expect(device.online).toBe(true);
+      expect(device.cached).toBe(false);
+      expect(device.sleepMode).toBe(false);
+
+      expect(device.components.length).toBe(13);
+      expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Eth', 'Input', 'Light', 'MQTT', 'Sys', 'Sntp', 'WiFi', 'WS']);
+      expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'eth', 'input:0', 'input:1', 'light:0', 'mqtt', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+      expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+      expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+      expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('input:1')?.hasProperty('state')).toBe(true);
+
+      expect(device.getComponent('light:0')?.hasProperty('state')).toBe(true);
+      expect(device.getComponent('light:0')?.hasProperty('output')).toBe(true);
+      expect(device.getComponent('light:0')?.hasProperty('brightness')).toBe(true);
+      expect(device.getComponent('light:0')?.hasProperty('voltage')).toBe(true);
+      expect(device.getComponent('light:0')?.hasProperty('current')).toBe(true);
+      expect(device.getComponent('light:0')?.hasProperty('apower')).toBe(true);
+      expect(device.getComponent('light:0')?.hasProperty('aenergy')).toBe(true);
+      expect((device.getComponent('light:0')?.getValue('aenergy') as ShellyData).total).toBeGreaterThanOrEqual(0);
+
+      expect(await device.fetchUpdate()).not.toBeNull();
+
+      if (device) device.destroy();
+    });
   });
 });


### PR DESCRIPTION
### Breaking Changes

- Unless you are using docker (in that case all is already updated when you pull the image), please update Matterbridge to 1.5.4 to work with matterbridge-shelly >= 0.9.5.  This is a one time issue due to the update to matter.js 0.10.0.

## [0.9.7] - 2024-09-09

### Added

- [config]: Added option "postfix" to postfix the matter serial number to avoid eventual collisions with other devices on the network (default empty string).
- [config]: Added option "failsafeCount" to avoid to start the bridge when some network issue prevents to load all devices (default 0 = disabled).
- [matterbridge]: Added a check of the current Matterbridge version (required v1.5.4).

### Verified

- [shelly]: Verified shellyprodm1pm with firmware v. 1.4.2 and added Jest test (this device needs to be calibrated to enable level control).
- [shelly]: Verified shelly1g3 with firmware v. 1.4.2 and added Jest test.
- [shelly]: Verified shelly1pmg3 with firmware v. 1.4.2 and added Jest test.
- [shelly]: Verified shellyi4g3 with firmware v. 1.4.2 and added Jest test.


### Changed

- [package]: Updated dependencies.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>
