### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
-- [shelly]: Added scheduled_restart event from Sys to set the devices that will not be loadd from cache at restart.
+- [shelly]: Added scheduled_restart event from Sys to set the devices that will not be loaded from cache at restart.
+- [shelly]: Added component Devicepower.
+- [shellyplussmoke]: Added battery readings (battery level and voltage) to shellyplussmoke and shellyhtg3 (all devices with Devicepower component).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 If you like this project and find it useful, please consider giving it a star on GitHub at https://github.com/Luligu/matterbridge-shelly and sponsoring it.
 
-## [1.0.2] - 2024-10-14
+## [1.0.2] - 2024-10-13
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 If you like this project and find it useful, please consider giving it a star on GitHub at https://github.com/Luligu/matterbridge-shelly and sponsoring it.
 
+## [1.0.2] - 2024-10-14
+
+### Added
+
+- [shelly]: Added scheduled_restart event from Sys to set the devices that will not be loadd from cache at restart.
+
+### Fixed
+
+- [BTHome]: Fixed issue to BTHome components discovery.
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
 
 ## [1.0.1] - 2024-10-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-shelly",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-shelly",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001668",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
+      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
       "dev": true,
       "funding": [
         {
@@ -3099,9 +3099,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.35",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.35.tgz",
-      "integrity": "sha512-hOSRInrIDm0Brzp4IHW2F/VM+638qOL2CzE0DgpnGzKW27C95IqqeqgKz/hxHGnvPxvQGpHUGD5qRVC9EZY2+A==",
+      "version": "1.5.36",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.36.tgz",
+      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -9,6 +9,7 @@ import { ShellyPlatform } from './platform';
 import { ShellyDevice } from './shellyDevice';
 import path from 'path';
 import { Shelly } from './shelly';
+import { CYAN } from 'node-ansi-logger';
 
 describe('ShellyPlatform', () => {
   let mockMatterbridge: Matterbridge;
@@ -384,7 +385,7 @@ describe('ShellyPlatform', () => {
     shellyPlatform.storedDevices.set('shellyemg3-84FCE636582C', { id: 'shellyemg3-84FCE636582C', host: 'invalid', port: 80, gen: 1 });
     shellyPlatform.storedDevices.set('shellyplus-34FCE636582C', { id: 'shellyplus-34FCE636582C', host: '192.168.255.1', port: 80, gen: 2 });
     expect(await (shellyPlatform as any).saveStoredDevices()).toBeTruthy();
-    expect(mockLog.debug).toHaveBeenCalledWith(`Saving 2 discovered Shelly devices to the storage`);
+    expect(mockLog.debug).toHaveBeenCalledWith(`Saving ${CYAN}2${db} discovered Shelly devices to the storage`);
     expect((shellyPlatform as any).storedDevices.size).toBe(2);
 
     await shellyPlatform.onStart('Test reason');

--- a/src/shellyDevice.mock.test.ts
+++ b/src/shellyDevice.mock.test.ts
@@ -1078,8 +1078,22 @@ describe('Shelly devices test', () => {
       expect(device.cached).toBe(false);
       expect(device.sleepMode).toBe(false);
 
-      expect(device.components.length).toBe(12);
-      expect(device.getComponentNames()).toStrictEqual(['Ble', 'WiFi', 'Switch', 'Input', 'Temperature', 'Humidity', 'Illuminance', 'Sys', 'Sntp', 'Cloud', 'MQTT', 'WS']);
+      expect(device.components.length).toBe(13);
+      expect(device.getComponentNames()).toStrictEqual([
+        'Ble',
+        'WiFi',
+        'Switch',
+        'Input',
+        'Temperature',
+        'Humidity',
+        'Illuminance',
+        'Sys',
+        'Sntp',
+        'Cloud',
+        'MQTT',
+        'WS',
+        'Devicepower',
+      ]);
       expect(device.getComponentIds()).toStrictEqual([
         'ble',
         'wifi_sta',
@@ -1093,6 +1107,7 @@ describe('Shelly devices test', () => {
         'cloud',
         'mqtt',
         'ws',
+        'devicepower:0',
       ]);
 
       expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
@@ -1132,7 +1147,7 @@ describe('Shelly devices test', () => {
       expect(device.cached).toBe(false);
       expect(device.sleepMode).toBe(false);
 
-      expect(device.components.length).toBe(13);
+      expect(device.components.length).toBe(14);
       expect(device.getComponentNames()).toStrictEqual([
         'Ble',
         'WiFi',
@@ -1147,6 +1162,7 @@ describe('Shelly devices test', () => {
         'MQTT',
         'WS',
         'Thermostat',
+        'Devicepower',
       ]);
       expect(device.getComponentIds()).toStrictEqual([
         'ble',
@@ -1162,6 +1178,7 @@ describe('Shelly devices test', () => {
         'mqtt',
         'ws',
         'thermostat:0',
+        'devicepower:0',
       ]);
 
       expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
@@ -1477,9 +1494,9 @@ describe('Shelly devices test', () => {
       expect(device.cached).toBe(false);
       expect(device.sleepMode).toBe(true);
 
-      expect(device.components.length).toBe(10);
-      expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'MQTT', 'Smoke', 'Sys', 'Sntp', 'WiFi', 'WS']);
-      expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'mqtt', 'smoke:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+      expect(device.components.length).toBe(11);
+      expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Devicepower', 'MQTT', 'Smoke', 'Sys', 'Sntp', 'WiFi', 'WS']);
+      expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'devicepower:0', 'mqtt', 'smoke:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
 
       expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
       expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -650,6 +650,7 @@ export class ShellyDevice extends EventEmitter {
         if (key.startsWith('illuminance:')) device.addComponent(new ShellyComponent(device, key, 'Illuminance', settingsPayload[key] as ShellyData));
         if (key.startsWith('smoke:')) device.addComponent(new ShellyComponent(device, key, 'Smoke', settingsPayload[key] as ShellyData));
         if (key.startsWith('thermostat:')) device.addComponent(new ShellyComponent(device, key, 'Thermostat', settingsPayload[key] as ShellyData));
+        if (key.startsWith('devicepower:')) device.addComponent(new ShellyComponent(device, key, 'Devicepower', settingsPayload[key] as ShellyData));
       }
 
       // Scan for BTHome devices and components
@@ -1020,6 +1021,9 @@ export class ShellyDevice extends EventEmitter {
         if (key.startsWith('illuminance:')) this.updateComponent(key, data[key] as ShellyData);
         if (key.startsWith('smoke:')) this.updateComponent(key, data[key] as ShellyData);
         if (key.startsWith('thermostat:')) this.updateComponent(key, data[key] as ShellyData);
+
+        if (key.startsWith('devicepower:') && !this.hasComponent(key)) this.addComponent(new ShellyComponent(this, key, 'Devicepower'));
+        if (key.startsWith('devicepower:')) this.updateComponent(key, data[key] as ShellyData);
       }
       // Update state for active components with output
       for (const key in data) {

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -663,7 +663,7 @@ export class ShellyDevice extends EventEmitter {
           offset += btHomePayload.components.length;
         }
       } while (btHomePayload && offset < btHomePayload.total);
-      componentsPayload = { components: btHomeComponents, cfg_rev: btHomePayload.cfg_rev, offset: 0, total: btHomeComponents.length };
+      componentsPayload = { components: btHomeComponents, cfg_rev: btHomePayload?.cfg_rev | 0, offset: 0, total: btHomeComponents.length };
       device.scanBTHomeComponents(btHomeComponents);
     }
 

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -726,7 +726,7 @@ export class ShellyDevice extends EventEmitter {
       // Check WebSocket client for gen 2 and 3 devices
       if (device.gen === 2 || device.gen === 3) {
         if (!device.sleepMode && device.wsClient?.isConnected === false) {
-          log.notice(`WebSocket client for device ${hk}${device.id}${nt} host ${zb}${device.host}${nt} is not connected. Starting connection...`);
+          log.info(`WebSocket client for device ${hk}${device.id}${nf} host ${zb}${device.host}${nf} is not connected. Starting connection...`);
           device.wsClient?.start();
         }
       }


### PR DESCRIPTION
## [1.0.2] - 2024-10-13

### Added

- [shelly]: Added scheduled_restart event from Sys to set the devices that will not be loaded from cache at restart.
- [shelly]: Added component Devicepower.
- [shellyplussmoke]: Added battery readings (battery level and voltage) to shellyplussmoke and shellyhtg3 (all devices with Devicepower component).

### Fixed

- [BTHome]: Fixed issue to BTHome components discovery.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>