### PR TITLE
fix: added correct interface for rock-s0

### DIFF
--- a/rock-s0/systemd/matterbridge.service
+++ b/rock-s0/systemd/matterbridge.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=matterbridge -service -passcode 20242025 -discriminator 3840
+ExecStart=matterbridge -service -passcode 20242025 -discriminator 3840 -mdnsinterface end0
 WorkingDirectory=/home/rock/Matterbridge
 StandardOutput=inherit
 StandardError=inherit


### PR DESCRIPTION
Since rock-s0 will have always same name for nic device, i thing here is the correct place to set it.