### PR TITLE
Release 2.0.10

### DIFF
--- a/.github/workflows/build-matterbridge-plugin.yml
+++ b/.github/workflows/build-matterbridge-plugin.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,26 @@ New device types:
 - shellysmoke device type has been updated from contact sensor to smoke sensor.
 - the device type for all the rgb lights has been updated from colorTemperatureLight to extendedColorLight. This solves SmartThings issues with color lights.
 
-If your controller has issues detecting the new device type, blacklist these devices, restart, remove the blacklist and restart again. This will create a new endpoint on the controller.
+If your controller has issues detecting the new device type, blacklist these devices, restart, wait 5 minutes, remove the blacklist and restart again. This will create a new endpoint on the controller.
 For shellyflood, if you have SmartThings, blacklist the Temperature entity for each flood device with deviceEntityBlackList to allow the controller to setup the correct driver.
+
+## [2.0.10] - 2025-05-??
+
+### Added
+
+### Changed
+
+- [package]: Updated package.
+- [package]: Updated dependencies.
+- [plugin]: Requires Matterbridge 3.0.0.
+
+### Fixed
+
+- [energy]: Fixed reading of energy component.
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
+</a>
 
 ## [2.0.9] - 2025-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his invaluable contribution to this project.
 
-### Breaking Changes
-
-New device types:
-
-- shellyflood device type has been updated from contact sensor to water leak sensor.
-- shellysmoke device type has been updated from contact sensor to smoke sensor.
-- the device type for all the rgb lights has been updated from colorTemperatureLight to extendedColorLight. This solves SmartThings issues with color lights.
-
-If your controller has issues detecting the new device type, blacklist these devices, restart, wait 5 minutes, remove the blacklist and restart again. This will create a new endpoint on the controller.
-For shellyflood, if you have SmartThings, blacklist the Temperature entity for each flood device with deviceEntityBlackList to allow the controller to setup the correct driver.
-
-## [2.0.10] - 2025-05-25
+## [2.0.10] - 2025-05-26
 
 ### Added
 
@@ -63,6 +52,17 @@ For shellyflood, if you have SmartThings, blacklist the Temperature entity for e
 </a>
 
 ## [2.0.8] - 2025-04-19
+
+### Breaking Changes
+
+New device types:
+
+- shellyflood device type has been updated from contact sensor to water leak sensor.
+- shellysmoke device type has been updated from contact sensor to smoke sensor.
+- the device type for all the rgb lights has been updated from colorTemperatureLight to extendedColorLight. This solves SmartThings issues with color lights.
+
+If your controller has issues detecting the new device type, blacklist these devices, restart, wait 5 minutes, remove the blacklist and restart again. This will create a new endpoint on the controller.
+For shellyflood, if you have SmartThings, blacklist the Temperature entity for each flood device with deviceEntityBlackList to allow the controller to setup the correct driver.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ For shellyflood, if you have SmartThings, blacklist the Temperature entity for e
 
 ### Added
 
+- [shelly]: Verified firmware 1.6.2.
+- [shelly]: Verified firmware 1.6.1.
+
 ### Changed
 
 - [package]: Updated package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ New device types:
 If your controller has issues detecting the new device type, blacklist these devices, restart, wait 5 minutes, remove the blacklist and restart again. This will create a new endpoint on the controller.
 For shellyflood, if you have SmartThings, blacklist the Temperature entity for each flood device with deviceEntityBlackList to allow the controller to setup the correct driver.
 
-## [2.0.10] - 2025-05-??
+## [2.0.10] - 2025-05-25
 
 ### Added
 
@@ -29,11 +29,12 @@ For shellyflood, if you have SmartThings, blacklist the Temperature entity for e
 
 - [package]: Updated package.
 - [package]: Updated dependencies.
-- [plugin]: Requires Matterbridge 3.0.0.
+- [plugin]: Requires Matterbridge 3.0.4.
 
 ### Fixed
 
-- [energy]: Fixed reading of energy component.
+- [energy]: Fixed reading of energy component coming not rounded from certain devices.
+- [mcast]: Fixed detection of coap setting in old gen1 devices.
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="bmc-button.svg" alt="Buy me a coffee" width="80">

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the complete guidelines on [Matterbridge](https://github.com/Luligu/matterbr
 
 ### Any shelly device
 
-A shelly device gen. 1 or 2 or 3 or BLU.
+A shelly device gen. 1 or 2 or 3 or 4 or BLU.
 
 ## How to add a device
 
@@ -109,6 +109,8 @@ There are two ways to have the wifi device IP stable:
 
 1. In your router configuration find, in the DHCP settings, the option to reserve an ip address for all your shelly wifi devices.
 2. In the device web UI (or Shelly app) go to Settings / WiFi and set a static IP for Wi-Fi 1 settings.
+
+A stable IP address is mandatory for battery powered devices. I suggest to set it for all the other devices too.
 
 ## How to install the plugin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.0.10-dev.1",
+  "version": "2.0.10-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-shelly",
-      "version": "2.0.10-dev.1",
+      "version": "2.0.10-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "coap": "1.4.1",
@@ -2491,9 +2491,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.157",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
+      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,36 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.0.9",
+  "version": "2.0.10-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-shelly",
-      "version": "2.0.9",
+      "version": "2.0.10-dev.1",
       "license": "Apache-2.0",
       "dependencies": {
         "coap": "1.4.1",
         "multicast-dns": "7.2.5",
         "node-ansi-logger": "3.0.1",
         "node-persist-manager": "1.0.8",
-        "ws": "8.18.1"
+        "ws": "8.18.2"
       },
       "devDependencies": {
-        "@eslint/js": "^9.25.1",
+        "@eslint/js": "^9.27.0",
         "@types/jest": "29.5.14",
         "@types/multicast-dns": "7.2.4",
-        "@types/node": "22.15.3",
+        "@types/node": "22.15.21",
         "@types/ws": "8.18.1",
         "cross-env": "7.0.3",
-        "eslint-config-prettier": "10.1.2",
+        "eslint-config-prettier": "10.1.5",
         "eslint-plugin-jest": "28.11.0",
-        "eslint-plugin-n": "17.17.0",
-        "eslint-plugin-prettier": "5.2.6",
+        "eslint-plugin-n": "17.18.0",
+        "eslint-plugin-prettier": "5.4.0",
         "jest": "29.7.0",
         "prettier": "3.5.3",
-        "ts-jest": "29.3.2",
+        "ts-jest": "29.3.4",
         "typescript": "5.8.3",
-        "typescript-eslint": "8.31.1"
+        "typescript-eslint": "8.32.1"
       },
       "engines": {
         "node": ">=18.0.0 <19.0.0 || >=20.0.0 <21.0.0 || >=22.0.0"
@@ -55,24 +55,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
+      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -80,22 +80,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
+      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helpers": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -121,14 +121,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -138,14 +138,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.8",
-        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -175,29 +175,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
+      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -247,27 +247,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.27.1"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -332,13 +332,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -374,13 +374,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -500,13 +500,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -516,32 +516,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -560,14 +560,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -581,9 +581,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
-      "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -650,9 +650,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -689,13 +689,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
-      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -710,14 +713,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.14.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -781,9 +784,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1472,22 +1475,21 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
-      "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.19.tgz",
+      "integrity": "sha512-6Tgd3lMocKwOul/kwAAgSebkhdMCLhRvcJ6CKHA6wdql2qNIwK6hw3Y4PZQxn9HcJogoC/1ZOmkFM7OZKH/VrA==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1525,21 +1527,21 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
-      "integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
+      "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.31.1",
-        "@typescript-eslint/type-utils": "8.31.1",
-        "@typescript-eslint/utils": "8.31.1",
-        "@typescript-eslint/visitor-keys": "8.31.1",
+        "@typescript-eslint/scope-manager": "8.32.1",
+        "@typescript-eslint/type-utils": "8.32.1",
+        "@typescript-eslint/utils": "8.32.1",
+        "@typescript-eslint/visitor-keys": "8.32.1",
         "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1554,17 +1556,27 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
-      "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
+      "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.31.1",
-        "@typescript-eslint/types": "8.31.1",
-        "@typescript-eslint/typescript-estree": "8.31.1",
-        "@typescript-eslint/visitor-keys": "8.31.1",
+        "@typescript-eslint/scope-manager": "8.32.1",
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/typescript-estree": "8.32.1",
+        "@typescript-eslint/visitor-keys": "8.32.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1580,14 +1592,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
-      "integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+      "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.1",
-        "@typescript-eslint/visitor-keys": "8.31.1"
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/visitor-keys": "8.32.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1598,16 +1610,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
-      "integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+      "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.31.1",
-        "@typescript-eslint/utils": "8.31.1",
+        "@typescript-eslint/typescript-estree": "8.32.1",
+        "@typescript-eslint/utils": "8.32.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1622,9 +1634,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
-      "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+      "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1636,20 +1648,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
-      "integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+      "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.1",
-        "@typescript-eslint/visitor-keys": "8.31.1",
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/visitor-keys": "8.32.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1689,16 +1701,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
-      "integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+      "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.31.1",
-        "@typescript-eslint/types": "8.31.1",
-        "@typescript-eslint/typescript-estree": "8.31.1"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.32.1",
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/typescript-estree": "8.32.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1713,13 +1725,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
-      "integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+      "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/types": "8.32.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -2046,9 +2058,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
       "dev": true,
       "funding": [
         {
@@ -2066,10 +2078,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
+        "caniuse-lite": "^1.0.30001716",
+        "electron-to-chromium": "^1.5.149",
         "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2153,9 +2165,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001716",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
-      "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "dev": true,
       "funding": [
         {
@@ -2381,9 +2393,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2398,9 +2410,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2479,9 +2491,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.145",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.145.tgz",
-      "integrity": "sha512-pZ5EcTWRq/055MvSBgoFEyKf2i4apwfoqJbK/ak2jnFq8oHjZ+vzc3AhRcz37Xn+ZJfL58R666FLJx0YOK9yTw==",
+      "version": "1.5.155",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
+      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
       "dev": true,
       "license": "ISC"
     },
@@ -2554,9 +2566,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
-      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2565,10 +2577,10 @@
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.20.0",
         "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.25.1",
-        "@eslint/plugin-kit": "^0.2.8",
+        "@eslint/js": "9.27.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2632,13 +2644,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
-      "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -2693,9 +2708,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.17.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.17.0.tgz",
-      "integrity": "sha512-2VvPK7Mo73z1rDFb6pTvkH6kFibAmnTubFq5l83vePxu0WiY1s0LOtj2WHb6Sa40R3w4mnh8GFYbHBQyMlotKw==",
+      "version": "17.18.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.18.0.tgz",
+      "integrity": "sha512-hvZ/HusueqTJ7VDLoCpjN0hx4N4+jHIWTXD4TMLHy9F23XkDagR9v+xQWRWR57yY55GPF8NnD4ox9iGTxirY8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2758,9 +2773,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.6.tgz",
-      "integrity": "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
+      "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3233,9 +3248,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5117,15 +5132,29 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5242,26 +5271,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -5364,14 +5373,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
-      "integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.6.tgz",
+      "integrity": "sha512-2pR2ubZSV64f/vqm9eLPz/KOvR9Dm+Co/5ChLgeHl0yEDRc6h5hXHoxEQH8Y5Ljycozd3p1k5TTSVdzYGkPvLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.3",
-        "tslib": "^2.8.1"
+        "@pkgr/core": "^0.2.4"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -5381,9 +5389,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5445,9 +5453,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
-      "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
+      "version": "29.3.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
+      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5458,8 +5466,8 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.1",
-        "type-fest": "^4.39.1",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -5495,9 +5503,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.40.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.1.tgz",
-      "integrity": "sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -5506,13 +5514,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5566,15 +5567,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
-      "integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
+      "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.31.1",
-        "@typescript-eslint/parser": "8.31.1",
-        "@typescript-eslint/utils": "8.31.1"
+        "@typescript-eslint/eslint-plugin": "8.32.1",
+        "@typescript-eslint/parser": "8.32.1",
+        "@typescript-eslint/utils": "8.32.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5728,9 +5729,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.0.10-rc.1",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-shelly",
-      "version": "2.0.10-rc.1",
+      "version": "2.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "coap": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.0.9",
+  "version": "2.0.10-dev.1",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "homepage": "https://github.com/Luligu/matterbridge-shelly/blob/main/README.md",
@@ -114,23 +114,23 @@
     "multicast-dns": "7.2.5",
     "node-ansi-logger": "3.0.1",
     "node-persist-manager": "1.0.8",
-    "ws": "8.18.1"
+    "ws": "8.18.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.25.1",
+    "@eslint/js": "^9.27.0",
     "@types/jest": "29.5.14",
     "@types/multicast-dns": "7.2.4",
-    "@types/node": "22.15.3",
+    "@types/node": "22.15.21",
     "@types/ws": "8.18.1",
     "cross-env": "7.0.3",
-    "eslint-config-prettier": "10.1.2",
+    "eslint-config-prettier": "10.1.5",
     "eslint-plugin-jest": "28.11.0",
-    "eslint-plugin-n": "17.17.0",
-    "eslint-plugin-prettier": "5.2.6",
+    "eslint-plugin-n": "17.18.0",
+    "eslint-plugin-prettier": "5.4.0",
     "jest": "29.7.0",
     "prettier": "3.5.3",
-    "ts-jest": "29.3.2",
+    "ts-jest": "29.3.4",
     "typescript": "5.8.3",
-    "typescript-eslint": "8.31.1"
+    "typescript-eslint": "8.32.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.0.10-dev.1",
+  "version": "2.0.10-rc.1",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "homepage": "https://github.com/Luligu/matterbridge-shelly/blob/main/README.md",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.0.10-rc.1",
+  "version": "2.0.10",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
-  "homepage": "https://github.com/Luligu/matterbridge-shelly/blob/main/README.md",
+  "homepage": "https://www.npmjs.com/package/matterbridge-shelly",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/src/coapServer.test.ts
+++ b/src/coapServer.test.ts
@@ -132,8 +132,8 @@ describe('Coap scanner', () => {
   });
 
   test('Parse status message', async () => {
-    (coapServer as any).deviceId.set('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
-    msg.rsinfo.address = '192.168.1.184';
+    (coapServer as any).deviceId.set('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
+    msg.rsinfo.address = '192.168.68.99';
     msg.payload = JSON.stringify(msg.payloadS) as any;
     msg.url = '/cit/s';
     const data = (coapServer as any).parseShellyMessage(msg as unknown as IncomingMessage);
@@ -141,20 +141,20 @@ describe('Coap scanner', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining('Parsing CoIoT (coap) response from device'));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`url: ${CYAN}/cit/s${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`code: ${CYAN}2.05${db}`));
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`host: ${CYAN}192.168.1.184${db}`));
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`host: ${CYAN}192.168.68.99${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceId: ${CYAN}shellydimmer2-98CDAC0D01BB${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceModel: ${CYAN}SHDM-2${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceMac: ${CYAN}98CDAC0D01BB${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`protocolRevision: ${CYAN}2${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(
       LogLevel.INFO,
-      expect.stringContaining(`No coap description found for ${hk}SHDM-2${nf} id ${hk}shellydimmer2-98CDAC0D01BB${nf} host ${zb}192.168.1.184${nf} fetching it...`),
+      expect.stringContaining(`No coap description found for ${hk}SHDM-2${nf} id ${hk}shellydimmer2-98CDAC0D01BB${nf} host ${zb}192.168.68.99${nf} fetching it...`),
     );
   });
 
   test('Parse description message', async () => {
-    (coapServer as any).deviceId.set('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
-    msg.rsinfo.address = '192.168.1.184';
+    (coapServer as any).deviceId.set('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
+    msg.rsinfo.address = '192.168.68.99';
     msg.payload = JSON.stringify(msg.payloadD) as any;
     msg.url = '/cit/d';
     const data = (coapServer as any).parseShellyMessage(msg as unknown as IncomingMessage);
@@ -179,7 +179,7 @@ describe('Coap scanner', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining('Parsing CoIoT (coap) response from device'));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`url: ${CYAN}/cit/d${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`code: ${CYAN}2.05${db}`));
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`host: ${CYAN}192.168.1.184${db}`));
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`host: ${CYAN}192.168.68.99${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceId: ${CYAN}shellydimmer2-98CDAC0D01BB${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceModel: ${CYAN}SHDM-2${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceMac: ${CYAN}98CDAC0D01BB${db}`));
@@ -187,8 +187,8 @@ describe('Coap scanner', () => {
   });
 
   test('Parse status message after description', async () => {
-    (coapServer as any).deviceId.set('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
-    msg.rsinfo.address = '192.168.1.184';
+    (coapServer as any).deviceId.set('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
+    msg.rsinfo.address = '192.168.68.99';
     msg.payload = JSON.stringify(msg.payloadS) as any;
     msg.url = '/cit/s';
     msg.headers = { '3332': 'SHDM-2#98CDAC0D01BB#2', '3412': 123, '3420': 456 };
@@ -208,7 +208,7 @@ describe('Coap scanner', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining('Parsing CoIoT (coap) response from device'));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`url: ${CYAN}/cit/s${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`code: ${CYAN}2.05${db}`));
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`host: ${CYAN}192.168.1.184${db}`));
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`host: ${CYAN}192.168.68.99${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceId: ${CYAN}shellydimmer2-98CDAC0D01BB${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceModel: ${CYAN}SHDM-2${db}`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`deviceMac: ${CYAN}98CDAC0D01BB${db}`));
@@ -879,12 +879,12 @@ describe('Coap scanner', () => {
   });
 
   test('Getting device description', async () => {
-    await coapServer.getDeviceDescription('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
+    await coapServer.getDeviceDescription('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
     expect(coapServer.isListening).toBeFalsy();
   }, 30000);
 
   test('Getting device status', async () => {
-    await coapServer.getDeviceStatus('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
+    await coapServer.getDeviceStatus('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
     expect(coapServer?.isListening).toBeFalsy();
   }, 30000);
 
@@ -907,8 +907,8 @@ describe('Coap scanner', () => {
     expect(coapServer.isListening).toBeTruthy();
 
     await new Promise((resolve) => {
-      coapServer.getDeviceDescription('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
-      coapServer.getDeviceStatus('192.168.1.184', 'shellydimmer2-98CDAC0D01BB');
+      coapServer.getDeviceDescription('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
+      coapServer.getDeviceStatus('192.168.68.99', 'shellydimmer2-98CDAC0D01BB');
 
       setInterval(() => {
         if (parseShellyMessageSpy.mock.calls.length > 0) {
@@ -923,7 +923,7 @@ describe('Coap scanner', () => {
 
   test('Stop scanner', async () => {
     coapServer.stop();
-    await new Promise((resolve) => setTimeout(() => resolve(true), 500).unref());
+    await new Promise((resolve) => setTimeout(() => resolve(true), 5000).unref());
     expect(coapServer.isListening).toBeFalsy();
     expect(coapServer.isReady).toBeFalsy();
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'Stopping CoIoT (coap) server for shelly devices...');

--- a/src/coapServer.ts
+++ b/src/coapServer.ts
@@ -25,7 +25,7 @@
 import { AnsiLogger, BLUE, CYAN, LogLevel, MAGENTA, RESET, TimestampFormat, db, debugStringify, er, hk, nf, wr, zb } from 'matterbridge/logger';
 
 // CoAP imports
-import coap, { Server, IncomingMessage, OutgoingMessage, parameters } from 'coap';
+import coap, { Server, IncomingMessage, OutgoingMessage, parameters, globalAgent } from 'coap';
 
 // Node.js imports
 import EventEmitter from 'node:events';
@@ -749,8 +749,8 @@ export class CoapServer extends EventEmitter {
    * This method stops the CoIoT server by performing the following actions:
    * - Logs a message indicating the server is being stopped.
    * - Removes all event listeners.
-   * - Closes the global agent.
    * - Closes the `coapServer` if it exists.
+   * - Closes the global agent.
    * - Clears the `devices` map.
    * - Logs a message indicating the server has been stopped.
    */
@@ -758,12 +758,12 @@ export class CoapServer extends EventEmitter {
     this.log.info('Stopping CoIoT (coap) server for shelly devices...');
     this.removeAllListeners();
     this._isListening = false;
-    // globalAgent.close((err?: Error) => this.log.debug(`CoIoT (coap) agent closed${err ? ' with error ' + err.message : ''}.`));
     if (this.coapServer)
       this.coapServer.close((err?: Error) => {
         this._isReady = false;
         this.log.debug(`CoIoT (coap) server closed${err ? ' with error ' + err.message : ''}.`);
       });
+    globalAgent.close((err?: Error) => this.log.debug(`CoIoT (coap) agent closed${err ? ' with error ' + err.message : ''}.`));
     this.deviceDescription.clear();
     this.deviceId.clear();
     this.deviceSerial.clear();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,7 +36,7 @@ describe('initializePlugin', () => {
     matterbridgeDirectory: './jest/matterbridge',
     matterbridgePluginDirectory: './jest/plugins',
     systemInformation: { ipv4Address: undefined, osRelease: 'xx.xx.xx.xx.xx.xx', nodeVersion: '22.1.10' },
-    matterbridgeVersion: '3.0.0',
+    matterbridgeVersion: '3.0.4',
     edge: false,
     log: mockLog,
     getDevices: jest.fn(() => {

--- a/src/mdnsScanner.test.ts
+++ b/src/mdnsScanner.test.ts
@@ -640,15 +640,17 @@ describe('Shellies MdnsScanner test', () => {
 
   test('Run multiple test gen 4', async () => {
     const tests = [
-      { id: 'shelly1minig4-7C2C67643858', host: '10.101.7.248', port: 80, gen: 4 },
-      { id: 'shelly1pmminig4-7C2C67640B4C', host: '10.101.1.87', port: 80, gen: 4 },
+      // On site
+      { id: 'shelly1g4-A085E3BCA4C8', host: '192.168.70.1', port: 80, gen: 4 },
+      { id: 'shelly1pmg4-A085E3BD0544', host: '192.168.70.3', port: 80, gen: 4 },
+      { id: 'shelly1minig4-A085E3BB944C', host: '192.168.70.2', port: 80, gen: 4 },
+      { id: 'shelly1pmminig4-CCBA97C64580', host: '192.168.70.4', port: 80, gen: 4 },
+      // Shelly HQ
       { id: 'shelly2pmg4-7C2C677A0110', host: '10.101.4.150', port: 80, gen: 4 },
       { id: 'shellyemminig4-7C2C6763F75C', host: '10.101.10.89', port: 80, gen: 4 },
       { id: 'shellyi4g4-F0F5BD287ACC', host: '10.101.5.95', port: 80, gen: 4 },
       { id: 'shellyplugusg4-7C2C67642A88', host: '10.101.6.97', port: 80, gen: 4 },
       { id: 'shellypstripg4-7C2C6763F7B0', host: '10.101.10.172', port: 80, gen: 4 },
-      { id: 'shelly1g4-A085E3BCA4C8', host: '192.168.1.190', port: 80, gen: 4 },
-      { id: 'shelly1pmg4-A085E3BD0544', host: '192.168.1.191', port: 80, gen: 4 },
     ];
 
     for (const test of tests) {
@@ -704,8 +706,8 @@ describe('Shellies MdnsScanner test', () => {
   }, 5000);
 
   test('Log discovered', () => {
-    expect((mdns as any).devices.size).toBeGreaterThanOrEqual(61);
-    expect((mdns as any).discoveredDevices.size).toBeGreaterThanOrEqual(61);
+    expect((mdns as any).devices.size).toBeGreaterThanOrEqual(58);
+    expect((mdns as any).discoveredDevices.size).toBeGreaterThanOrEqual(58);
     const size = mdns.logPeripheral();
     expect(size).toBeGreaterThanOrEqual(61);
   });

--- a/src/mock/shelly1g4-A085E3BCA4C8.json
+++ b/src/mock/shelly1g4-A085E3BCA4C8.json
@@ -3,11 +3,11 @@
     "name": "1 Gen4",
     "id": "shelly1g4-a085e3bca4c8",
     "mac": "A085E3BCA4C8",
-    "slot": 0,
+    "slot": 1,
     "model": "S4SW-001X16EU",
     "gen": 4,
-    "fw_id": "20250214-121709/1.5.99-g4prod1-gc32c24b",
-    "ver": "1.5.99-g4prod1",
+    "fw_id": "20250520-083720/1.6.2-gc8a76e2",
+    "ver": "1.6.2",
     "app": "S1G4",
     "auth_en": false,
     "auth_domain": null,
@@ -15,15 +15,15 @@
   },
   "settings": {
     "ble": {
-      "enable": true,
+      "enable": false,
       "rpc": {
-        "enable": true
+        "enable": false
       }
     },
     "bthome": {},
     "cloud": {
-      "enable": false,
-      "server": "iot.shelly.cloud:6012/jrpc"
+      "enable": true,
+      "server": "shelly-103-eu.shelly.cloud:6022/jrpc"
     },
     "input:0": {
       "id": 0,
@@ -41,6 +41,9 @@
       }
     },
     "matter": {
+      "enable": true
+    },
+    "modbus": {
       "enable": true
     },
     "mqtt": {
@@ -71,7 +74,7 @@
       "device": {
         "name": "1 Gen4",
         "mac": "A085E3BCA4C8",
-        "fw_id": "20250214-121709/1.5.99-g4prod1-gc32c24b",
+        "fw_id": "20250520-083720/1.6.2-gc8a76e2",
         "discoverable": true,
         "eco_mode": false,
         "addon_type": null
@@ -98,7 +101,7 @@
       "sntp": {
         "server": "time.cloudflare.com"
       },
-      "cfg_rev": 6
+      "cfg_rev": 19
     },
     "wifi": {
       "ap": {
@@ -121,8 +124,8 @@
       },
       "sta1": {
         "ssid": "",
-        "is_open": true,
-        "enable": false,
+        "is_open": false,
+        "enable": true,
         "ipv4mode": "dhcp",
         "ip": null,
         "netmask": null,
@@ -142,64 +145,83 @@
   },
   "status": {
     "ble": {},
-    "bthome": {},
+    "bthome": {
+      "errors": [
+        "bluetooth_disabled"
+      ]
+    },
     "cloud": {
-      "connected": false
+      "connected": true
     },
     "input:0": {
       "id": 0,
-      "state": false
+      "state": true
     },
     "knx": {},
     "matter": {
-      "num_fabrics": 0,
+      "num_fabrics": 1,
       "commissionable": false
     },
+    "modbus": {},
     "mqtt": {
       "connected": false
     },
     "switch:0": {
       "id": 0,
-      "source": "switch",
-      "output": false,
+      "source": "init",
+      "output": true,
       "temperature": {
-        "tC": 47.2,
-        "tF": 116.9
+        "tC": 52.9,
+        "tF": 127.3
       }
     },
     "sys": {
       "mac": "A085E3BCA4C8",
       "restart_required": false,
-      "time": "08:32",
-      "unixtime": 1743147126,
-      "last_sync_ts": 1743146558,
-      "uptime": 54725,
-      "ram_size": 360772,
-      "ram_free": 169152,
-      "ram_min_free": 152568,
+      "time": "13:01",
+      "unixtime": 1748257269,
+      "last_sync_ts": 1748255664,
+      "uptime": 412747,
+      "ram_size": 360032,
+      "ram_free": 184756,
+      "ram_min_free": 167056,
       "fs_size": 917504,
-      "fs_free": 458752,
-      "cfg_rev": 6,
+      "fs_free": 442368,
+      "cfg_rev": 19,
       "kvs_rev": 0,
       "schedule_rev": 1,
       "webhook_rev": 0,
       "btrelay_rev": 0,
       "available_updates": {},
+      "alt": {
+        "S1G4ZB": {
+          "name": "Shelly 1 Gen4",
+          "desc": "Shelly 1 with Zigbee",
+          "stable": {
+            "version": "1.6.2",
+            "build_id": "20250520-083719/1.6.2-gc8a76e2"
+          }
+        }
+      },
       "reset_reason": 3,
-      "utc_offset": 3600
+      "utc_offset": 7200
     },
     "wifi": {
-      "sta_ip": "192.168.1.190",
+      "sta_ip": "192.168.70.1",
       "status": "got ip",
       "ssid": "",
-      "rssi": -51
+      "rssi": -53,
+      "sta_ip6": [
+        "fe80::a285:e3ff:febc:a4c8",
+        "fd78:cbf8:4939:746:a285:e3ff:febc:a4c8"
+      ]
     },
     "ws": {
       "connected": false
     }
   },
   "components": [],
-  "cfg_rev": 6,
+  "cfg_rev": 19,
   "offset": 0,
   "total": 0
 }

--- a/src/mock/shelly1g4-A085E3BCA4C8.json
+++ b/src/mock/shelly1g4-A085E3BCA4C8.json
@@ -146,9 +146,7 @@
   "status": {
     "ble": {},
     "bthome": {
-      "errors": [
-        "bluetooth_disabled"
-      ]
+      "errors": ["bluetooth_disabled"]
     },
     "cloud": {
       "connected": true
@@ -211,10 +209,7 @@
       "status": "got ip",
       "ssid": "",
       "rssi": -53,
-      "sta_ip6": [
-        "fe80::a285:e3ff:febc:a4c8",
-        "fd78:cbf8:4939:746:a285:e3ff:febc:a4c8"
-      ]
+      "sta_ip6": ["fe80::a285:e3ff:febc:a4c8", "fd78:cbf8:4939:746:a285:e3ff:febc:a4c8"]
     },
     "ws": {
       "connected": false

--- a/src/mock/shelly1g4-A085E3BCA4C8.mdns.json
+++ b/src/mock/shelly1g4-A085E3BCA4C8.mdns.json
@@ -52,11 +52,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=S1G4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=S1G4", "ver=1.6.2"]
     },
     {
       "name": "Shelly1G4-A085E3BCA4C8.local",
@@ -85,11 +81,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=S1G4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=S1G4", "ver=1.6.2"]
     },
     {
       "name": "1-Gen4.local",

--- a/src/mock/shelly1g4-A085E3BCA4C8.mdns.json
+++ b/src/mock/shelly1g4-A085E3BCA4C8.mdns.json
@@ -15,18 +15,26 @@
   "questions": [],
   "answers": [
     {
-      "name": "_http._tcp.local",
+      "name": "_shelly._tcp.local",
       "type": "PTR",
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": "shelly1g4-a085e3bca4c8._http._tcp.local"
+      "data": "shelly1g4-a085e3bca4c8._shelly._tcp.local"
+    },
+    {
+      "name": "_shelly._tcp.local",
+      "type": "PTR",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": "1 Gen4._shelly._tcp.local"
     }
   ],
   "authorities": [],
   "additionals": [
     {
-      "name": "shelly1g4-a085e3bca4c8._http._tcp.local",
+      "name": "shelly1g4-a085e3bca4c8._shelly._tcp.local",
       "type": "SRV",
       "ttl": 120,
       "class": "IN",
@@ -39,12 +47,16 @@
       }
     },
     {
-      "name": "shelly1g4-a085e3bca4c8._http._tcp.local",
+      "name": "shelly1g4-a085e3bca4c8._shelly._tcp.local",
       "type": "TXT",
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": ["gen=4"]
+      "data": [
+        "gen=4",
+        "app=S1G4",
+        "ver=1.6.2"
+      ]
     },
     {
       "name": "Shelly1G4-A085E3BCA4C8.local",
@@ -52,7 +64,40 @@
       "ttl": 120,
       "class": "IN",
       "flush": true,
-      "data": "192.168.1.190"
+      "data": "192.168.70.1"
+    },
+    {
+      "name": "1 Gen4._shelly._tcp.local",
+      "type": "SRV",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": {
+        "priority": 0,
+        "weight": 0,
+        "port": 80,
+        "target": "1-Gen4.local"
+      }
+    },
+    {
+      "name": "1 Gen4._shelly._tcp.local",
+      "type": "TXT",
+      "ttl": 120,
+      "class": "IN",
+      "flush": false,
+      "data": [
+        "gen=4",
+        "app=S1G4",
+        "ver=1.6.2"
+      ]
+    },
+    {
+      "name": "1-Gen4.local",
+      "type": "A",
+      "ttl": 120,
+      "class": "IN",
+      "flush": true,
+      "data": "192.168.70.1"
     }
   ]
 }

--- a/src/mock/shelly1minig4-A085E3BB944C.json
+++ b/src/mock/shelly1minig4-A085E3BB944C.json
@@ -1,14 +1,14 @@
 {
   "shelly": {
-    "name": "1PM Gen4",
-    "id": "shelly1pmg4-a085e3bd0544",
-    "mac": "A085E3BD0544",
+    "name": "1 Mini Gen4",
+    "id": "shelly1minig4-a085e3bb944c",
+    "mac": "A085E3BB944C",
     "slot": 0,
-    "model": "S4SW-001P16EU",
+    "model": "S4SW-001X8EU",
     "gen": 4,
-    "fw_id": "20250520-083727/1.6.2-gc8a76e2",
+    "fw_id": "20250520-083709/1.6.2-gc8a76e2",
     "ver": "1.6.2",
-    "app": "S1PMG4",
+    "app": "Mini1G4",
     "auth_en": false,
     "auth_domain": null,
     "matter": true
@@ -49,10 +49,10 @@
     "mqtt": {
       "enable": false,
       "server": null,
-      "client_id": "shelly1pmg4-a085e3bd0544",
+      "client_id": "shelly1minig4-a085e3bb944c",
       "user": null,
       "ssl_ca": null,
-      "topic_prefix": "shelly1pmg4-a085e3bd0544",
+      "topic_prefix": "shelly1minig4-a085e3bb944c",
       "rpc_ntf": true,
       "status_ntf": false,
       "use_client_cert": false,
@@ -68,21 +68,15 @@
       "auto_on": false,
       "auto_on_delay": 60,
       "auto_off": false,
-      "auto_off_delay": 60,
-      "power_limit": 4480,
-      "voltage_limit": 280,
-      "autorecover_voltage_errors": false,
-      "current_limit": 16,
-      "reverse": false
+      "auto_off_delay": 60
     },
     "sys": {
       "device": {
-        "name": "1PM Gen4",
-        "mac": "A085E3BD0544",
-        "fw_id": "20250520-083727/1.6.2-gc8a76e2",
+        "name": "1 Mini Gen4",
+        "mac": "A085E3BB944C",
+        "fw_id": "20250520-083709/1.6.2-gc8a76e2",
         "discoverable": true,
-        "eco_mode": false,
-        "addon_type": null
+        "eco_mode": false
       },
       "location": null,
       "debug": {
@@ -106,7 +100,7 @@
       "sntp": {
         "server": "time.cloudflare.com"
       },
-      "cfg_rev": 20
+      "cfg_rev": 18
     },
     "wifi": {
       "ap": {
@@ -175,58 +169,36 @@
       "id": 0,
       "source": "init",
       "output": false,
-      "apower": 0,
-      "voltage": 234.2,
-      "freq": 49.9,
-      "current": 0,
-      "aenergy": {
-        "total": 0,
-        "by_minute": [
-          0,
-          0,
-          0
-        ],
-        "minute_ts": 1748257260
-      },
-      "ret_aenergy": {
-        "total": 0,
-        "by_minute": [
-          0,
-          0,
-          0
-        ],
-        "minute_ts": 1748257260
-      },
       "temperature": {
-        "tC": 46.2,
-        "tF": 115.2
+        "tC": 59.6,
+        "tF": 139.3
       }
     },
     "sys": {
-      "mac": "A085E3BD0544",
+      "mac": "A085E3BB944C",
       "restart_required": false,
-      "time": "13:01",
-      "unixtime": 1748257309,
-      "last_sync_ts": 1748256862,
-      "uptime": 412787,
-      "ram_size": 358736,
-      "ram_free": 182484,
-      "ram_min_free": 160804,
+      "time": "12:59",
+      "unixtime": 1748257189,
+      "last_sync_ts": 1748255602,
+      "uptime": 412667,
+      "ram_size": 361320,
+      "ram_free": 187808,
+      "ram_min_free": 169008,
       "fs_size": 917504,
-      "fs_free": 442368,
-      "cfg_rev": 20,
+      "fs_free": 458752,
+      "cfg_rev": 18,
       "kvs_rev": 0,
       "schedule_rev": 1,
       "webhook_rev": 0,
       "btrelay_rev": 0,
       "available_updates": {},
       "alt": {
-        "S1PMG4ZB": {
-          "name": "Shelly 1 PM Gen4",
-          "desc": "Shelly 1 PM Gen4 with Zigbee",
+        "Mini1G4ZB": {
+          "name": "Shelly Mini 1 Gen4",
+          "desc": "Shelly Mini 1 Gen4 with Zigbee",
           "stable": {
             "version": "1.6.2",
-            "build_id": "20250520-083719/1.6.2-gc8a76e2"
+            "build_id": "20250520-083722/1.6.2-gc8a76e2"
           }
         }
       },
@@ -234,13 +206,13 @@
       "utc_offset": 7200
     },
     "wifi": {
-      "sta_ip": "192.168.70.3",
+      "sta_ip": "192.168.70.2",
       "status": "got ip",
       "ssid": "",
-      "rssi": -51,
+      "rssi": -57,
       "sta_ip6": [
-        "fe80::a285:e3ff:febd:544",
-        "fd78:cbf8:4939:746:a285:e3ff:febd:544"
+        "fe80::a285:e3ff:febb:944c",
+        "fd78:cbf8:4939:746:a285:e3ff:febb:944c"
       ]
     },
     "ws": {
@@ -248,7 +220,7 @@
     }
   },
   "components": [],
-  "cfg_rev": 20,
+  "cfg_rev": 18,
   "offset": 0,
   "total": 0
 }

--- a/src/mock/shelly1minig4-A085E3BB944C.json
+++ b/src/mock/shelly1minig4-A085E3BB944C.json
@@ -145,9 +145,7 @@
   "status": {
     "ble": {},
     "bthome": {
-      "errors": [
-        "bluetooth_disabled"
-      ]
+      "errors": ["bluetooth_disabled"]
     },
     "cloud": {
       "connected": true
@@ -210,10 +208,7 @@
       "status": "got ip",
       "ssid": "",
       "rssi": -57,
-      "sta_ip6": [
-        "fe80::a285:e3ff:febb:944c",
-        "fd78:cbf8:4939:746:a285:e3ff:febb:944c"
-      ]
+      "sta_ip6": ["fe80::a285:e3ff:febb:944c", "fd78:cbf8:4939:746:a285:e3ff:febb:944c"]
     },
     "ws": {
       "connected": false

--- a/src/mock/shelly1minig4-A085E3BB944C.mdns.json
+++ b/src/mock/shelly1minig4-A085E3BB944C.mdns.json
@@ -52,11 +52,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=Mini1G4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=Mini1G4", "ver=1.6.2"]
     },
     {
       "name": "Shelly1MiniG4-A085E3BB944C.local",
@@ -85,11 +81,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=Mini1G4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=Mini1G4", "ver=1.6.2"]
     },
     {
       "name": "1-Mini-Gen4.local",

--- a/src/mock/shelly1minig4-A085E3BB944C.mdns.json
+++ b/src/mock/shelly1minig4-A085E3BB944C.mdns.json
@@ -20,7 +20,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": "shelly1pmg4-a085e3bd0544._shelly._tcp.local"
+      "data": "shelly1minig4-a085e3bb944c._shelly._tcp.local"
     },
     {
       "name": "_shelly._tcp.local",
@@ -28,13 +28,13 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": "1PM Gen4._shelly._tcp.local"
+      "data": "1 Mini Gen4._shelly._tcp.local"
     }
   ],
   "authorities": [],
   "additionals": [
     {
-      "name": "shelly1pmg4-a085e3bd0544._shelly._tcp.local",
+      "name": "shelly1minig4-a085e3bb944c._shelly._tcp.local",
       "type": "SRV",
       "ttl": 120,
       "class": "IN",
@@ -43,31 +43,31 @@
         "priority": 0,
         "weight": 0,
         "port": 80,
-        "target": "Shelly1PMG4-A085E3BD0544.local"
+        "target": "Shelly1MiniG4-A085E3BB944C.local"
       }
     },
     {
-      "name": "shelly1pmg4-a085e3bd0544._shelly._tcp.local",
+      "name": "shelly1minig4-a085e3bb944c._shelly._tcp.local",
       "type": "TXT",
       "ttl": 120,
       "class": "IN",
       "flush": false,
       "data": [
         "gen=4",
-        "app=S1PMG4",
+        "app=Mini1G4",
         "ver=1.6.2"
       ]
     },
     {
-      "name": "Shelly1PMG4-A085E3BD0544.local",
+      "name": "Shelly1MiniG4-A085E3BB944C.local",
       "type": "A",
       "ttl": 120,
       "class": "IN",
       "flush": true,
-      "data": "192.168.70.3"
+      "data": "192.168.70.2"
     },
     {
-      "name": "1PM Gen4._shelly._tcp.local",
+      "name": "1 Mini Gen4._shelly._tcp.local",
       "type": "SRV",
       "ttl": 120,
       "class": "IN",
@@ -76,28 +76,28 @@
         "priority": 0,
         "weight": 0,
         "port": 80,
-        "target": "1PM-Gen4.local"
+        "target": "1-Mini-Gen4.local"
       }
     },
     {
-      "name": "1PM Gen4._shelly._tcp.local",
+      "name": "1 Mini Gen4._shelly._tcp.local",
       "type": "TXT",
       "ttl": 120,
       "class": "IN",
       "flush": false,
       "data": [
         "gen=4",
-        "app=S1PMG4",
+        "app=Mini1G4",
         "ver=1.6.2"
       ]
     },
     {
-      "name": "1PM-Gen4.local",
+      "name": "1-Mini-Gen4.local",
       "type": "A",
       "ttl": 120,
       "class": "IN",
       "flush": true,
-      "data": "192.168.70.3"
+      "data": "192.168.70.2"
     }
   ]
 }

--- a/src/mock/shelly1pmg4-A085E3BD0544.json
+++ b/src/mock/shelly1pmg4-A085E3BD0544.json
@@ -151,9 +151,7 @@
   "status": {
     "ble": {},
     "bthome": {
-      "errors": [
-        "bluetooth_disabled"
-      ]
+      "errors": ["bluetooth_disabled"]
     },
     "cloud": {
       "connected": true
@@ -181,20 +179,12 @@
       "current": 0,
       "aenergy": {
         "total": 0,
-        "by_minute": [
-          0,
-          0,
-          0
-        ],
+        "by_minute": [0, 0, 0],
         "minute_ts": 1748257260
       },
       "ret_aenergy": {
         "total": 0,
-        "by_minute": [
-          0,
-          0,
-          0
-        ],
+        "by_minute": [0, 0, 0],
         "minute_ts": 1748257260
       },
       "temperature": {
@@ -238,10 +228,7 @@
       "status": "got ip",
       "ssid": "",
       "rssi": -51,
-      "sta_ip6": [
-        "fe80::a285:e3ff:febd:544",
-        "fd78:cbf8:4939:746:a285:e3ff:febd:544"
-      ]
+      "sta_ip6": ["fe80::a285:e3ff:febd:544", "fd78:cbf8:4939:746:a285:e3ff:febd:544"]
     },
     "ws": {
       "connected": false

--- a/src/mock/shelly1pmg4-A085E3BD0544.mdns.json
+++ b/src/mock/shelly1pmg4-A085E3BD0544.mdns.json
@@ -52,11 +52,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=S1PMG4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=S1PMG4", "ver=1.6.2"]
     },
     {
       "name": "Shelly1PMG4-A085E3BD0544.local",
@@ -85,11 +81,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=S1PMG4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=S1PMG4", "ver=1.6.2"]
     },
     {
       "name": "1PM-Gen4.local",

--- a/src/mock/shelly1pmminig4-CCBA97C64580.json
+++ b/src/mock/shelly1pmminig4-CCBA97C64580.json
@@ -1,14 +1,14 @@
 {
   "shelly": {
-    "name": "1PM Gen4",
-    "id": "shelly1pmg4-a085e3bd0544",
-    "mac": "A085E3BD0544",
-    "slot": 0,
-    "model": "S4SW-001P16EU",
+    "name": "1PM Mini Gen4",
+    "id": "shelly1pmminig4-ccba97c64580",
+    "mac": "CCBA97C64580",
+    "slot": 1,
+    "model": "S4SW-001P8EU",
     "gen": 4,
-    "fw_id": "20250520-083727/1.6.2-gc8a76e2",
+    "fw_id": "20250520-083702/1.6.2-gc8a76e2",
     "ver": "1.6.2",
-    "app": "S1PMG4",
+    "app": "Mini1PMG4",
     "auth_en": false,
     "auth_domain": null,
     "matter": true
@@ -49,10 +49,10 @@
     "mqtt": {
       "enable": false,
       "server": null,
-      "client_id": "shelly1pmg4-a085e3bd0544",
+      "client_id": "shelly1pmminig4-ccba97c64580",
       "user": null,
       "ssl_ca": null,
-      "topic_prefix": "shelly1pmg4-a085e3bd0544",
+      "topic_prefix": "shelly1pmminig4-ccba97c64580",
       "rpc_ntf": true,
       "status_ntf": false,
       "use_client_cert": false,
@@ -69,20 +69,19 @@
       "auto_on_delay": 60,
       "auto_off": false,
       "auto_off_delay": 60,
-      "power_limit": 4480,
+      "power_limit": 2240,
       "voltage_limit": 280,
       "autorecover_voltage_errors": false,
-      "current_limit": 16,
+      "current_limit": 8,
       "reverse": false
     },
     "sys": {
       "device": {
-        "name": "1PM Gen4",
-        "mac": "A085E3BD0544",
-        "fw_id": "20250520-083727/1.6.2-gc8a76e2",
+        "name": "1PM Mini Gen4",
+        "mac": "CCBA97C64580",
+        "fw_id": "20250520-083702/1.6.2-gc8a76e2",
         "discoverable": true,
-        "eco_mode": false,
-        "addon_type": null
+        "eco_mode": false
       },
       "location": null,
       "debug": {
@@ -106,7 +105,7 @@
       "sntp": {
         "server": "time.cloudflare.com"
       },
-      "cfg_rev": 20
+      "cfg_rev": 37
     },
     "wifi": {
       "ap": {
@@ -176,8 +175,8 @@
       "source": "init",
       "output": false,
       "apower": 0,
-      "voltage": 234.2,
-      "freq": 49.9,
+      "voltage": 234.6,
+      "freq": 50,
       "current": 0,
       "aenergy": {
         "total": 0,
@@ -186,7 +185,7 @@
           0,
           0
         ],
-        "minute_ts": 1748257260
+        "minute_ts": 1748257020
       },
       "ret_aenergy": {
         "total": 0,
@@ -195,38 +194,38 @@
           0,
           0
         ],
-        "minute_ts": 1748257260
+        "minute_ts": 1748257020
       },
       "temperature": {
-        "tC": 46.2,
-        "tF": 115.2
+        "tC": 63.4,
+        "tF": 146
       }
     },
     "sys": {
-      "mac": "A085E3BD0544",
+      "mac": "CCBA97C64580",
       "restart_required": false,
-      "time": "13:01",
-      "unixtime": 1748257309,
-      "last_sync_ts": 1748256862,
-      "uptime": 412787,
-      "ram_size": 358736,
-      "ram_free": 182484,
-      "ram_min_free": 160804,
+      "time": "12:57",
+      "unixtime": 1748257049,
+      "last_sync_ts": 1748255584,
+      "uptime": 412524,
+      "ram_size": 359624,
+      "ram_free": 180688,
+      "ram_min_free": 162912,
       "fs_size": 917504,
-      "fs_free": 442368,
-      "cfg_rev": 20,
+      "fs_free": 458752,
+      "cfg_rev": 37,
       "kvs_rev": 0,
       "schedule_rev": 1,
       "webhook_rev": 0,
       "btrelay_rev": 0,
       "available_updates": {},
       "alt": {
-        "S1PMG4ZB": {
-          "name": "Shelly 1 PM Gen4",
-          "desc": "Shelly 1 PM Gen4 with Zigbee",
+        "Mini1PMG4ZB": {
+          "name": "Shelly Mini 1 PM Gen4",
+          "desc": "Shelly Mini 1 PM Gen4 with Zigbee",
           "stable": {
             "version": "1.6.2",
-            "build_id": "20250520-083719/1.6.2-gc8a76e2"
+            "build_id": "20250520-083659/1.6.2-gc8a76e2"
           }
         }
       },
@@ -234,13 +233,13 @@
       "utc_offset": 7200
     },
     "wifi": {
-      "sta_ip": "192.168.70.3",
+      "sta_ip": "192.168.70.4",
       "status": "got ip",
       "ssid": "",
-      "rssi": -51,
+      "rssi": -55,
       "sta_ip6": [
-        "fe80::a285:e3ff:febd:544",
-        "fd78:cbf8:4939:746:a285:e3ff:febd:544"
+        "fe80::ceba:97ff:fec6:4580",
+        "fd78:cbf8:4939:746:ceba:97ff:fec6:4580"
       ]
     },
     "ws": {
@@ -248,7 +247,7 @@
     }
   },
   "components": [],
-  "cfg_rev": 20,
+  "cfg_rev": 37,
   "offset": 0,
   "total": 0
 }

--- a/src/mock/shelly1pmminig4-CCBA97C64580.json
+++ b/src/mock/shelly1pmminig4-CCBA97C64580.json
@@ -150,9 +150,7 @@
   "status": {
     "ble": {},
     "bthome": {
-      "errors": [
-        "bluetooth_disabled"
-      ]
+      "errors": ["bluetooth_disabled"]
     },
     "cloud": {
       "connected": true
@@ -180,20 +178,12 @@
       "current": 0,
       "aenergy": {
         "total": 0,
-        "by_minute": [
-          0,
-          0,
-          0
-        ],
+        "by_minute": [0, 0, 0],
         "minute_ts": 1748257020
       },
       "ret_aenergy": {
         "total": 0,
-        "by_minute": [
-          0,
-          0,
-          0
-        ],
+        "by_minute": [0, 0, 0],
         "minute_ts": 1748257020
       },
       "temperature": {
@@ -237,10 +227,7 @@
       "status": "got ip",
       "ssid": "",
       "rssi": -55,
-      "sta_ip6": [
-        "fe80::ceba:97ff:fec6:4580",
-        "fd78:cbf8:4939:746:ceba:97ff:fec6:4580"
-      ]
+      "sta_ip6": ["fe80::ceba:97ff:fec6:4580", "fd78:cbf8:4939:746:ceba:97ff:fec6:4580"]
     },
     "ws": {
       "connected": false

--- a/src/mock/shelly1pmminig4-CCBA97C64580.mdns.json
+++ b/src/mock/shelly1pmminig4-CCBA97C64580.mdns.json
@@ -52,11 +52,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=Mini1PMG4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=Mini1PMG4", "ver=1.6.2"]
     },
     {
       "name": "Shelly1PMMiniG4-CCBA97C64580.local",
@@ -85,11 +81,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": [
-        "gen=4",
-        "app=Mini1PMG4",
-        "ver=1.6.2"
-      ]
+      "data": ["gen=4", "app=Mini1PMG4", "ver=1.6.2"]
     },
     {
       "name": "1PM-Mini-Gen4.local",

--- a/src/mock/shelly1pmminig4-CCBA97C64580.mdns.json
+++ b/src/mock/shelly1pmminig4-CCBA97C64580.mdns.json
@@ -20,7 +20,7 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": "shelly1pmg4-a085e3bd0544._shelly._tcp.local"
+      "data": "shelly1pmminig4-ccba97c64580._shelly._tcp.local"
     },
     {
       "name": "_shelly._tcp.local",
@@ -28,13 +28,13 @@
       "ttl": 120,
       "class": "IN",
       "flush": false,
-      "data": "1PM Gen4._shelly._tcp.local"
+      "data": "1PM Mini Gen4._shelly._tcp.local"
     }
   ],
   "authorities": [],
   "additionals": [
     {
-      "name": "shelly1pmg4-a085e3bd0544._shelly._tcp.local",
+      "name": "shelly1pmminig4-ccba97c64580._shelly._tcp.local",
       "type": "SRV",
       "ttl": 120,
       "class": "IN",
@@ -43,31 +43,31 @@
         "priority": 0,
         "weight": 0,
         "port": 80,
-        "target": "Shelly1PMG4-A085E3BD0544.local"
+        "target": "Shelly1PMMiniG4-CCBA97C64580.local"
       }
     },
     {
-      "name": "shelly1pmg4-a085e3bd0544._shelly._tcp.local",
+      "name": "shelly1pmminig4-ccba97c64580._shelly._tcp.local",
       "type": "TXT",
       "ttl": 120,
       "class": "IN",
       "flush": false,
       "data": [
         "gen=4",
-        "app=S1PMG4",
+        "app=Mini1PMG4",
         "ver=1.6.2"
       ]
     },
     {
-      "name": "Shelly1PMG4-A085E3BD0544.local",
+      "name": "Shelly1PMMiniG4-CCBA97C64580.local",
       "type": "A",
       "ttl": 120,
       "class": "IN",
       "flush": true,
-      "data": "192.168.70.3"
+      "data": "192.168.70.4"
     },
     {
-      "name": "1PM Gen4._shelly._tcp.local",
+      "name": "1PM Mini Gen4._shelly._tcp.local",
       "type": "SRV",
       "ttl": 120,
       "class": "IN",
@@ -76,28 +76,28 @@
         "priority": 0,
         "weight": 0,
         "port": 80,
-        "target": "1PM-Gen4.local"
+        "target": "1PM-Mini-Gen4.local"
       }
     },
     {
-      "name": "1PM Gen4._shelly._tcp.local",
+      "name": "1PM Mini Gen4._shelly._tcp.local",
       "type": "TXT",
       "ttl": 120,
       "class": "IN",
       "flush": false,
       "data": [
         "gen=4",
-        "app=S1PMG4",
+        "app=Mini1PMG4",
         "ver=1.6.2"
       ]
     },
     {
-      "name": "1PM-Gen4.local",
+      "name": "1PM-Mini-Gen4.local",
       "type": "A",
       "ttl": 120,
       "class": "IN",
       "flush": true,
-      "data": "192.168.70.3"
+      "data": "192.168.70.4"
     }
   ]
 }

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -1,19 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  Matterbridge,
-  // MatterbridgeBehavior,
-  MatterbridgeEndpoint,
-  PlatformConfig,
-  PowerSource,
-  MatterbridgeLevelControlServer,
-  MatterbridgeColorControlServer,
-  bridge,
-  ColorControl,
-  TemperatureMeasurementCluster,
-  RelativeHumidityMeasurementCluster,
-} from 'matterbridge';
+import { Matterbridge, MatterbridgeEndpoint, PlatformConfig, MatterbridgeLevelControlServer, MatterbridgeColorControlServer, bridge } from 'matterbridge';
 import {
   OnOffCluster,
   BindingCluster,
@@ -27,6 +15,10 @@ import {
   PowerSourceCluster,
   PowerTopology,
   Switch,
+  PowerSource,
+  ColorControl,
+  TemperatureMeasurementCluster,
+  RelativeHumidityMeasurementCluster,
 } from 'matterbridge/matter/clusters';
 import { ColorControlBehavior, LevelControlBehavior, OnOffBehavior, RelativeHumidityMeasurementBehavior, TemperatureMeasurementBehavior } from 'matterbridge/matter/behaviors';
 import { AnsiLogger, db, er, hk, idn, LogLevel, nf, rs, wr, zb, CYAN, TimestampFormat, YELLOW, or, debugStringify } from 'matterbridge/logger';
@@ -36,8 +28,6 @@ import {
   MaybePromise,
   LogLevel as MatterLogLevel,
   LogFormat as MatterLogFormat,
-  EndpointServer,
-  logEndpoint,
   DeviceTypeId,
   VendorId,
   ServerNode,
@@ -215,7 +205,7 @@ describe('ShellyPlatform', () => {
       matterbridgeDirectory: './jest/matterbridge',
       matterbridgePluginDirectory: './jest/plugins',
       systemInformation: { ipv4Address: undefined, osRelease: 'xx.xx.xx.xx.xx.xx', nodeVersion: '22.1.10' },
-      matterbridgeVersion: '3.0.0',
+      matterbridgeVersion: '3.0.4',
       log: mockLog,
       getDevices: jest.fn(() => {
         // console.log('getDevices called');
@@ -333,7 +323,7 @@ describe('ShellyPlatform', () => {
   it('should throw because of version', () => {
     mockMatterbridge.matterbridgeVersion = '1.5.4';
     expect(() => new ShellyPlatform(mockMatterbridge, mockLog, mockConfig as any)).toThrow();
-    mockMatterbridge.matterbridgeVersion = '3.0.0';
+    mockMatterbridge.matterbridgeVersion = '3.0.4';
   });
 
   it('should call onStart with reason and start mDNS', async () => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -164,9 +164,9 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
     super(matterbridge, log, config as unknown as PlatformConfig);
 
     // Verify that Matterbridge is the correct version
-    if (this.verifyMatterbridgeVersion === undefined || typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.0.0')) {
+    if (this.verifyMatterbridgeVersion === undefined || typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.0.4')) {
       throw new Error(
-        `This plugin requires Matterbridge version >= "3.0.0". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend."`,
+        `This plugin requires Matterbridge version >= "3.0.4". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend."`,
       );
     }
 

--- a/src/platformUpdateHandler.ts
+++ b/src/platformUpdateHandler.ts
@@ -350,7 +350,7 @@ export function shellyUpdateHandler(
     if ((property === 'power' || property === 'apower' || property === 'act_power') && isValidNumber(value, 0)) {
       if (property === 'power' && shellyComponent.id.startsWith('light') && shellyDevice.id.startsWith('shellyrgbw2')) return; // Skip the rest for shellyrgbw2 devices
       const power = Math.round(value * 1000) / 1000;
-      endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activePower', power * 1000, shellyDevice.log);
+      endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activePower', Math.round(power * 1000), shellyDevice.log);
       if (property === 'act_power') return; // Skip the rest for PRO devices
       if (shellyComponent.id.startsWith('emeter')) return; // Skip the rest for em3 devices
       if (shellyComponent.hasProperty('current')) return; // Skip if we have already current reading
@@ -358,35 +358,35 @@ export function shellyUpdateHandler(
       if (property === 'power' && shellyDevice.hasComponent('sys') && shellyDevice.getComponent('sys')?.hasProperty('voltage')) {
         const voltage = shellyDevice.getComponent('sys')?.getValue('voltage');
         if (isValidNumber(voltage, 10)) {
-          endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'voltage', voltage * 1000, shellyDevice.log);
+          endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'voltage', Math.round(voltage * 1000), shellyDevice.log);
           const current = Math.round((value / voltage) * 1000) / 1000;
-          endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent', current * 1000, shellyDevice.log);
+          endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent', Math.round(current * 1000), shellyDevice.log);
         }
       }
       // Calculate current from power and voltage
       const voltage = shellyComponent.hasProperty('voltage') ? (shellyComponent.getValue('voltage') as number) : undefined;
       if (isValidNumber(voltage, 10)) {
         const current = Math.round((value / voltage) * 1000) / 1000;
-        endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent', current * 1000, shellyDevice.log);
+        endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent', Math.round(current * 1000), shellyDevice.log);
       }
     }
     if (property === 'total' && isValidNumber(value, 0)) {
       const energy = Math.round(value * 1000) / 1000;
-      endpoint.setAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported', { energy: energy * 1000 }, shellyDevice.log);
+      endpoint.setAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported', { energy: Math.round(energy * 1000) }, shellyDevice.log);
     }
     if (property === 'aenergy' && isValidObject(value) && isValidNumber((value as ShellyData).total, 0)) {
       const energy = Math.round(((value as ShellyData).total as number) * 1000) / 1000;
-      endpoint.setAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported', { energy: energy * 1000 }, shellyDevice.log);
+      endpoint.setAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported', { energy: Math.round(energy * 1000) }, shellyDevice.log);
     }
     if (property === 'total_act_energy' && isValidNumber(value, 0)) {
       const energy = Math.round(value * 1000) / 1000;
-      endpoint.setAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported', { energy: energy * 1000 }, shellyDevice.log);
+      endpoint.setAttribute(ElectricalEnergyMeasurement.Cluster.id, 'cumulativeEnergyImported', { energy: Math.round(energy * 1000) }, shellyDevice.log);
     }
     if (property === 'voltage' && isValidNumber(value, 0)) {
-      endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'voltage', value * 1000, shellyDevice.log);
+      endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'voltage', Math.round(value * 1000), shellyDevice.log);
     }
     if (property === 'current' && isValidNumber(value, 0)) {
-      endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent', value * 1000, shellyDevice.log);
+      endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activeCurrent', Math.round(value * 1000), shellyDevice.log);
       if (shellyComponent.hasProperty('act_power')) return;
       if (shellyComponent.hasProperty('apower')) return;
       if (shellyComponent.hasProperty('power')) return;
@@ -395,7 +395,7 @@ export function shellyUpdateHandler(
       const voltage = shellyComponent.hasProperty('voltage') ? (shellyComponent.getValue('voltage') as number) : undefined;
       if (isValidNumber(voltage, 0)) {
         const power = Math.round(value * voltage * 1000) / 1000;
-        endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activePower', power * 1000, shellyDevice.log);
+        endpoint.setAttribute(ElectricalPowerMeasurement.Cluster.id, 'activePower', Math.round(power * 1000), shellyDevice.log);
       }
     }
   }

--- a/src/shellyDevice.mock.gen4.test.ts
+++ b/src/shellyDevice.mock.gen4.test.ts
@@ -1,0 +1,245 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { ShellyDevice } from './shellyDevice.js';
+import { AnsiLogger, TimestampFormat, LogLevel } from 'matterbridge/logger';
+import { Shelly } from './shelly.js';
+import { ShellyComponent } from './shellyComponent.js';
+import path from 'node:path';
+import { jest } from '@jest/globals';
+import { ShellyData } from './shellyTypes.js';
+import { wait } from 'matterbridge/utils';
+import { CoapServer } from './coapServer.js';
+import { WsServer } from './wsServer.js';
+
+describe('Shelly gen 4 devices test', () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+
+  jest.spyOn(CoapServer.prototype, 'start').mockImplementation(() => {
+    return;
+  });
+
+  jest.spyOn(WsServer.prototype, 'start').mockImplementation(() => {
+    return;
+  });
+
+  const log = new AnsiLogger({ logName: 'shellyDeviceTest', logTimestampFormat: TimestampFormat.TIME_MILLIS, logDebug: false });
+  const shelly = new Shelly(log, 'admin', 'tango');
+  let device: ShellyDevice | undefined = undefined;
+  let id: string;
+
+  const firmwareGen1 = 'v1.14.0-gcb84623';
+  const firmwareGen2 = '1.4.4-g6d2a586';
+  const firmwareGen3 = '1.5.0-g0087a06';
+  const firmwareGen4 = '1.6.2-gc8a76e2';
+
+  beforeAll(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+      // console.error(`Mocked console.log: ${args}`);
+    });
+  });
+
+  beforeEach(() => {
+    //
+  });
+
+  afterEach(() => {
+    if (device) device.destroy();
+  });
+
+  afterAll(async () => {
+    shelly.destroy();
+    await wait(2000);
+  });
+
+  test('Create a gen 4 shelly1g4 device', async () => {
+    id = 'shelly1g4-a085e3bca4c8';
+    log.logName = id;
+
+    device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+    expect(device).not.toBeUndefined();
+    if (!device) return;
+    expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+    expect(device.model).toBe('S4SW-001X16EU');
+    expect(device.mac).toBe('A085E3BCA4C8');
+    expect(device.id).toBe('shelly1g4-A085E3BCA4C8');
+    expect(device.firmware).toBe(firmwareGen4);
+    expect(device.auth).toBe(false);
+    expect(device.gen).toBe(4);
+    expect(device.profile).toBe(undefined);
+    expect(device.name).toBe('1 Gen4');
+    expect(device.hasUpdate).toBe(false);
+    expect(device.lastseen).not.toBe(0);
+    expect(device.online).toBe(true);
+    expect(device.cached).toBe(false);
+    expect(device.sleepMode).toBe(false);
+
+    expect(device.components.length).toBe(12);
+    expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'Matter', 'MQTT', 'Switch', 'Sys', 'Sntp', 'WiFi', 'WS']);
+    expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'matter', 'mqtt', 'switch:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+    expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+    expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+    expect(device.getComponent('matter')?.hasProperty('enable')).toBe(true);
+
+    expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+
+    expect(device.getComponent('switch:0')?.hasProperty('state')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('voltage')).toBe(false);
+    expect(device.getComponent('switch:0')?.hasProperty('current')).toBe(false);
+    expect(device.getComponent('switch:0')?.hasProperty('apower')).toBe(false);
+    expect(device.getComponent('switch:0')?.hasProperty('aenergy')).toBe(false);
+
+    expect(device.bthomeTrvs.size).toBe(0);
+    expect(device.bthomeDevices.size).toBe(0);
+    expect(device.bthomeSensors.size).toBe(0);
+
+    expect(await device.fetchUpdate()).not.toBeNull();
+
+    if (device) device.destroy();
+  });
+
+  test('Create a gen 4 shelly1pmg4 device', async () => {
+    id = 'shelly1pmg4-a085e3bd0544';
+    log.logName = id;
+
+    device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+    expect(device).not.toBeUndefined();
+    if (!device) return;
+    expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+    expect(device.model).toBe('S4SW-001P16EU');
+    expect(device.mac).toBe('A085E3BD0544');
+    expect(device.id).toBe('shelly1pmg4-A085E3BD0544');
+    expect(device.firmware).toBe(firmwareGen4);
+    expect(device.auth).toBe(false);
+    expect(device.gen).toBe(4);
+    expect(device.profile).toBe(undefined);
+    expect(device.name).toBe('1PM Gen4');
+    expect(device.hasUpdate).toBe(false);
+    expect(device.lastseen).not.toBe(0);
+    expect(device.online).toBe(true);
+    expect(device.cached).toBe(false);
+    expect(device.sleepMode).toBe(false);
+
+    expect(device.components.length).toBe(12);
+    expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'Matter', 'MQTT', 'Switch', 'Sys', 'Sntp', 'WiFi', 'WS']);
+    expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'matter', 'mqtt', 'switch:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+    expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+    expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+    expect(device.getComponent('matter')?.hasProperty('enable')).toBe(true);
+
+    expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+
+    expect(device.getComponent('switch:0')?.hasProperty('state')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('voltage')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('current')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('apower')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('aenergy')).toBe(true);
+
+    expect(device.bthomeTrvs.size).toBe(0);
+    expect(device.bthomeDevices.size).toBe(0);
+    expect(device.bthomeSensors.size).toBe(0);
+
+    expect(await device.fetchUpdate()).not.toBeNull();
+
+    if (device) device.destroy();
+  });
+
+  test('Create a gen 4 shelly1minig4 device', async () => {
+    id = 'shelly1minig4-a085e3bb944c';
+    log.logName = id;
+
+    device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+    expect(device).not.toBeUndefined();
+    if (!device) return;
+    expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+    expect(device.model).toBe('S4SW-001X8EU');
+    expect(device.mac).toBe('A085E3BB944C');
+    expect(device.id).toBe('shelly1minig4-A085E3BB944C');
+    expect(device.firmware).toBe(firmwareGen4);
+    expect(device.auth).toBe(false);
+    expect(device.gen).toBe(4);
+    expect(device.profile).toBe(undefined);
+    expect(device.name).toBe('1 Mini Gen4');
+    expect(device.hasUpdate).toBe(false);
+    expect(device.lastseen).not.toBe(0);
+    expect(device.online).toBe(true);
+    expect(device.cached).toBe(false);
+    expect(device.sleepMode).toBe(false);
+
+    expect(device.components.length).toBe(12);
+    expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'Matter', 'MQTT', 'Switch', 'Sys', 'Sntp', 'WiFi', 'WS']);
+    expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'matter', 'mqtt', 'switch:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+    expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+    expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+    expect(device.getComponent('matter')?.hasProperty('enable')).toBe(true);
+
+    expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+
+    expect(device.getComponent('switch:0')?.hasProperty('state')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('voltage')).toBe(false);
+    expect(device.getComponent('switch:0')?.hasProperty('current')).toBe(false);
+    expect(device.getComponent('switch:0')?.hasProperty('apower')).toBe(false);
+    expect(device.getComponent('switch:0')?.hasProperty('aenergy')).toBe(false);
+
+    expect(device.bthomeTrvs.size).toBe(0);
+    expect(device.bthomeDevices.size).toBe(0);
+    expect(device.bthomeSensors.size).toBe(0);
+
+    expect(await device.fetchUpdate()).not.toBeNull();
+
+    if (device) device.destroy();
+  });
+
+  test('Create a gen 4 shelly1pmminig4 device', async () => {
+    id = 'shelly1pmminig4-ccba97c64580';
+    log.logName = id;
+
+    device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
+    expect(device).not.toBeUndefined();
+    if (!device) return;
+    expect(device.host).toBe(path.join('src', 'mock', id + '.json'));
+    expect(device.model).toBe('S4SW-001P8EU');
+    expect(device.mac).toBe('CCBA97C64580');
+    expect(device.id).toBe('shelly1pmminig4-CCBA97C64580');
+    expect(device.firmware).toBe(firmwareGen4);
+    expect(device.auth).toBe(false);
+    expect(device.gen).toBe(4);
+    expect(device.profile).toBe(undefined);
+    expect(device.name).toBe('1PM Mini Gen4');
+    expect(device.hasUpdate).toBe(false);
+    expect(device.lastseen).not.toBe(0);
+    expect(device.online).toBe(true);
+    expect(device.cached).toBe(false);
+    expect(device.sleepMode).toBe(false);
+
+    expect(device.components.length).toBe(12);
+    expect(device.getComponentNames()).toStrictEqual(['Ble', 'Cloud', 'Input', 'Matter', 'MQTT', 'Switch', 'Sys', 'Sntp', 'WiFi', 'WS']);
+    expect(device.getComponentIds()).toStrictEqual(['ble', 'cloud', 'input:0', 'matter', 'mqtt', 'switch:0', 'sys', 'sntp', 'wifi_ap', 'wifi_sta', 'wifi_sta1', 'ws']);
+
+    expect(device.getComponent('sys')?.getValue('temperature')).toBe(undefined);
+    expect(device.getComponent('sys')?.getValue('overtemperature')).toBe(undefined);
+
+    expect(device.getComponent('matter')?.hasProperty('enable')).toBe(true);
+
+    expect(device.getComponent('input:0')?.hasProperty('state')).toBe(true);
+
+    expect(device.getComponent('switch:0')?.hasProperty('state')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('voltage')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('current')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('apower')).toBe(true);
+    expect(device.getComponent('switch:0')?.hasProperty('aenergy')).toBe(true);
+
+    expect(device.bthomeTrvs.size).toBe(0);
+    expect(device.bthomeDevices.size).toBe(0);
+    expect(device.bthomeSensors.size).toBe(0);
+
+    expect(await device.fetchUpdate()).not.toBeNull();
+
+    if (device) device.destroy();
+  });
+});

--- a/src/shellyDevice.mock.gen4.test.ts
+++ b/src/shellyDevice.mock.gen4.test.ts
@@ -52,7 +52,7 @@ describe('Shelly gen 4 devices test', () => {
   });
 
   test('Create a gen 4 shelly1g4 device', async () => {
-    id = 'shelly1g4-a085e3bca4c8';
+    id = 'shelly1g4-A085E3BCA4C8';
     log.logName = id;
 
     device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
@@ -100,7 +100,7 @@ describe('Shelly gen 4 devices test', () => {
   });
 
   test('Create a gen 4 shelly1pmg4 device', async () => {
-    id = 'shelly1pmg4-a085e3bd0544';
+    id = 'shelly1pmg4-A085E3BD0544';
     log.logName = id;
 
     device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
@@ -148,7 +148,7 @@ describe('Shelly gen 4 devices test', () => {
   });
 
   test('Create a gen 4 shelly1minig4 device', async () => {
-    id = 'shelly1minig4-a085e3bb944c';
+    id = 'shelly1minig4-A085E3BB944C';
     log.logName = id;
 
     device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));
@@ -196,7 +196,7 @@ describe('Shelly gen 4 devices test', () => {
   });
 
   test('Create a gen 4 shelly1pmminig4 device', async () => {
-    id = 'shelly1pmminig4-ccba97c64580';
+    id = 'shelly1pmminig4-CCBA97C64580';
     log.logName = id;
 
     device = await ShellyDevice.create(shelly, log, path.join('src', 'mock', id + '.json'));

--- a/src/shellyDevice.mock.test.ts
+++ b/src/shellyDevice.mock.test.ts
@@ -30,6 +30,7 @@ describe('Shelly devices test', () => {
   const firmwareGen1 = 'v1.14.0-gcb84623';
   const firmwareGen2 = '1.4.4-g6d2a586';
   const firmwareGen3 = '1.5.0-g0087a06';
+  const firmwareGen4 = '1.6.2-gc8a76e2';
 
   beforeAll(() => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -717,6 +717,7 @@ export class ShellyDevice extends EventEmitter {
     if (statusPayload) device.onUpdate(statusPayload);
 
     // For gen 1 devices check if CoIoT is enabled and peer is set correctly. First devices do not have this property.
+    // Devices like motionsensor and motion2 use multicast:5683 instead of mcast in peer.
     if (device.gen === 1) {
       const CoIoT = device.getComponent('coiot');
       if (CoIoT) {
@@ -725,7 +726,7 @@ export class ShellyDevice extends EventEmitter {
             `The CoIoT service is not enabled for device ${dn}${device.name}${wr} id ${hk}${device.id}${wr}. Enable it in the web ui settings to receive updates from the device.`,
           );
         // When peer is mcast we get "" as value. First devices do not have this property.
-        if (CoIoT.hasProperty('peer') && (CoIoT.getValue('peer') as string) !== '') {
+        if (CoIoT.hasProperty('peer') && CoIoT.getValue('peer') !== '' && CoIoT.getValue('peer') !== 'multicast:5683') {
           const peer = CoIoT.getValue('peer') as string;
           const ipv4 = shelly.ipv4Address + ':5683';
           if (peer !== ipv4)

--- a/src/wsServer.test.ts
+++ b/src/wsServer.test.ts
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { jest } from '@jest/globals';
-import { getMacAddress, wait, waiter } from 'matterbridge/utils';
+import { wait, waiter } from 'matterbridge/utils';
 import { WsServer } from './wsServer';
-import { WebSocket, WebSocketServer } from 'ws';
+import { WebSocket } from 'ws';
 import { AnsiLogger, LogLevel } from 'matterbridge/logger';
 import { ShellyData } from './shellyTypes';
-import * as http from 'node:http';
 
 describe('ShellyWsServer', () => {
   let wsServer: WsServer;
@@ -139,6 +138,8 @@ describe('ShellyWsServer', () => {
           client.ping();
           await wait(3000);
           client.close();
+          wsServer.stop();
+          await wait(1000);
           resolve();
         } catch (error) {
           reject(error);
@@ -161,5 +162,5 @@ describe('ShellyWsServer', () => {
         reject(error);
       });
     });
-  });
+  }, 10000);
 });


### PR DESCRIPTION
## [2.0.10] - 2025-05-26

### Added

- [shelly]: Verified firmware 1.6.2.
- [shelly]: Verified firmware 1.6.1.

### Changed

- [package]: Updated package.
- [package]: Updated dependencies.
- [plugin]: Requires Matterbridge 3.0.4.

### Fixed

- [energy]: Fixed reading of energy component coming not rounded from certain devices.
- [mcast]: Fixed detection of coap setting in old gen1 devices.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
</a>
