### PR TITLE
Release 2.5.1

### DIFF
--- a/.agents/chip-tests.md
+++ b/.agents/chip-tests.md
@@ -1,0 +1,296 @@
+# CHIP Conformance Test Harness (v.1.0.0)
+
+A Matterbridge plugin can be validated against the Matter CHIP certification test suite — both the Python
+test scripts and the YAML certification tests used by the CSA's own CI — running inside the
+`luligu/matterbridge:chip-test` Docker image. The harness is driven entirely by
+`scripts/run-chip-tests.mjs` and configured by `chipTests.json`, both dropped into the plugin repo's root.
+The script is not specific to any one plugin: it reads the plugin name, config, and test list from
+`chipTests.json`, so the same `run-chip-tests.mjs` works unmodified across plugin repos — copy it as-is and
+only author a `chipTests.json` for the new repo.
+
+## 1. What the container is
+
+- Image `luligu/matterbridge:chip-test` bundles a Matterbridge instance plus a full
+  `connectedhomeip`/`chip-tool` checkout with the Python test suite under `src/python_testing/` (relative
+  to the container's default working directory), the YAML certification test suite under
+  `src/app/tests/suites/certification/`, the YAML test runner CLI at
+  `scripts/tests/chipyaml/chiptool.py`, and `chip-tool` itself at `/root/connectedhomeip/out/host/chip-tool`.
+- The container is always named `chip-test` (`containerName` in the script).
+- `chip-tool`'s own persistent storage inside the image already holds a fabric paired with the matterbridge
+  instance, under node id `0x12344321` — this is what makes the YAML tests runnable without a separate
+  commissioning step (see §5). Verified directly: `chip-tool basicinformation read vendor-name 0x12344321 0`
+  reads back `VendorName: Matterbridge` against that existing pairing, no commissioning needed. There is no
+  long-running server process baked into the image; each YAML test invocation spawns its own short-lived
+  `chip-tool interactive server`, runs, and tears it down again.
+- The plugin's `node_modules` (under `/root/Matterbridge/<pluginName>/node_modules`) is shadowed by a named
+  Docker volume (`chip-test-node-modules`), not the host bind mount — this gives the container its own
+  independent, native-Linux-filesystem `node_modules`, since Matterbridge core re-links itself into a local
+  plugin's `node_modules` on every restart when it isn't already there, and running that against a Windows
+  bind mount over Docker Desktop's cross-OS file sharing is dramatically slower (a Windows-created
+  `node_modules/matterbridge` symlink also doesn't reliably resolve from inside the Linux container anyway).
+  The first-ever `--start` has to populate this volume from scratch, comparable to a full `npm install`, so
+  the container can take **2-3 minutes to report ready**; every `--start` after that finds it already
+  populated and skips straight past the re-link, coming up much faster. The named volume persists across
+  `docker rm`/`--start` cycles (only removed by an explicit `docker volume rm chip-test-node-modules`), so
+  this slow first run only happens once per host, not once per `--start`.
+- It runs on the `matterbridge` docker network, mapping the frontend to host port `8585`, mounting `./temp`
+  to `/tmp/matter_testing/logs` (test artifacts) and the plugin repo to `/root/Matterbridge/<pluginName>`,
+  where `<pluginName>` comes from `chipTests.json`'s `config.name`. `start()` creates this network itself
+  (`docker network inspect matterbridge || docker network create --ipv6 matterbridge`) if it doesn't already
+  exist, so a fresh host (including a CI runner, see §9) needs no separate setup step for it. The `--ipv6`
+  flag matters: the container relies on an IPv6 link-local address (e.g. `chip-tool`'s traffic to
+  `fe80::.../UDP:5540`, see §1's `0x12344321` pairing check above), so a plain IPv4-only network breaks it —
+  if the network already exists without `--ipv6` (e.g. created by hand or by another tool), `--start` reuses
+  it as-is rather than recreating it, so that pre-existing network still needs fixing manually.
+- The image bakes in a fixed set of environment variables (`Config.Env` in the Dockerfile, not something
+  `chipTests.json`/`run-chip-tests.mjs` sets — check with `docker inspect luligu/matterbridge:chip-test`).
+  As of this writing that includes `MATTERBRIDGE_CHIP_TEST=1` (a marker flag), `MATTERBRIDGE_START_CONFIGURE_TIMEOUT`/
+  `MATTERBRIDGE_START_REACHABILITY_TIMEOUT` (shorter Matterbridge-core startup timeouts tuned for a fast,
+  local, single-controller container), and one or more plugin-specific opt-in gates (e.g. a var that skips a
+  camera plugin's default-stream self-allocation, or one that switches a WebRTC command handler into strict
+  spec-validation mode instead of a lenient real-controller-friendly default) — these only do anything if
+  the plugin being tested actually reads them via `process.env` and chooses to change behavior accordingly;
+  the image itself doesn't enforce anything. Don't assume a specific plugin implements any of these gates —
+  check that plugin's own source (`process.env.MATTERBRIDGE_*` reads) rather than assuming parity with
+  another plugin, and re-run `docker inspect` for the current list rather than trusting a stale one here.
+- A curated PICS (Protocol Implementation Conformance Statement) file is baked into the image at
+  `/root/matterbridge.pics`, hand-verified against Matterbridge's own default cluster server
+  implementations (see `matterbridge/docker/chip-test/matterbridge.pics` in the `matterbridge` repo — the
+  source lives there, not in the plugin repo). Prefer this file over the generic
+  `src/app/tests/suites/certification/ci-pics-values` (the CSA's own near-blanket CI profile) whenever a
+  hand-verified section exists for the cluster under test — it is what makes tests like
+  `TC_BINFO_*`/`TC_BRBINFO_*` behave correctly instead of asserting on attributes a real device doesn't
+  support. If the cluster you're testing has no section yet in `matterbridge.pics`, either add one there
+  (cross-referencing the Matter spec and the real cluster-server source) or fall back to the generic PICS
+  file for that test.
+
+## 2. Lifecycle commands
+
+```shell
+node scripts/run-chip-tests.mjs --start   # create the container, npm install/link/build, copy the plugin in, matterbridge --add, write config, restart
+node scripts/run-chip-tests.mjs           # run every test in chipTests.json's "yamlTests" and "phytonTests" arrays against the running container
+node scripts/run-chip-tests.mjs --test X  # run only tests whose "name" or "test" (filename) includes X, case-insensitive substring match
+node scripts/run-chip-tests.mjs --stop    # docker stop the container, then npm install/link/build locally to restore the local dev environment
+```
+
+Expose these as `npm run` shortcuts in `package.json`, e.g. `chip:start`, `chip:test`, `chip:test:<cluster>`
+(filtered by the `TC_*` prefix of the test file), `chip:stop`. Add a new `chip:test:<name>` shortcut
+whenever a new cluster's tests are added to `chipTests.json`.
+
+**Always run `--stop` after any container-based investigation.** On Windows especially, `--start`/`--stop`
+swap `node_modules` native binaries (oxlint/oxfmt/tsc addons/etc.) between the container's platform (Linux,
+from the container-side npm install) and the local platform — until `--stop` has run and rebuilt cleanly,
+do not trust local lint/format/typecheck output.
+
+## 3. `chipTests.json` shape
+
+```jsonc
+{
+  "config": {
+    /* the plugin's config.json content, written into the container as
+       /root/.matterbridge/<config.name>.config.json before the final restart in --start.
+       "config.name" is also used as the plugin (npm package) name for the container's
+       volume mount and `matterbridge --add`. */
+  },
+  "resetClusterGlobs": [
+    /* filename globs, matched against files under this plugin's node storage directory for the
+       bridged endpoints, cleared by any test entry that sets "resetBefore": true or
+       "resetAfter": true. Only needs entries for cluster state that's actually persisted to disk —
+       the container restart that "resetBefore"/"resetAfter" also performs already clears any
+       cluster state kept purely in memory, with no glob needed for that. Required (non-empty) if
+       any test uses "resetBefore"/"resetAfter" — the script fails loudly rather than silently
+       skipping the reset if this is empty. */
+  ],
+  "yamlTests": [
+    // optional, defaults to []. "test" is a YAML certification test name (no extension, e.g.
+    // "Test_TC_I_2_1") from src/app/tests/suites/certification/, run via:
+    //   python3 scripts/tests/chipyaml/chiptool.py tests <test.test> <args...>
+    // This spawns a short-lived "chip-tool interactive server" for the duration of the one test, reusing
+    // chip-tool's own persisted fabric pairing baked into the image — see §5. Config values the YAML file
+    // declares (e.g. "endpoint") become CLI flags, so "args": ["--endpoint 6"] overrides the file's own
+    // default. Pass "--PICS /root/matterbridge.pics" in args when a hand-verified section exists for the
+    // cluster under test (see §1) — the tool's own default is the generic ci-pics-values file.
+    // "input"/"resetBefore"/"resetAfter"/"skip"/"comment" (documented on the phytonTests entry below) apply here identically —
+    // run-chip-tests.mjs's runTests() reads them off every entry in yamlTests/phytonTests the same way,
+    // regardless of kind.
+    {
+      "name": "Human-readable label, matched by --test",
+      "test": "Test_TC_SOMETHING_1_2",
+      "args": ["--endpoint 6"],
+      "input": "y\ny\n", // optional, piped to stdin for tests that prompt for interactive confirmation
+      "resetBefore": true, // optional: clear resetClusterGlobs + restart the container before this test
+      "resetAfter": true, // optional: clear resetClusterGlobs + restart the container after this test (before the next one) — put this on the test that leaves dirty residue, not the one affected by it
+      "skip": true, // optional: list the test (name, comment) but never invoke it — see below
+      "comment": "optional free text, printed under a failing/skipped result in the summary log",
+    },
+  ],
+  "phytonTests": [
+    // optional, defaults to [].
+    {
+      "name": "Human-readable label, matched by --test",
+      "test": "TC_SOMETHING_1_2.py", // filename under src/python_testing/ inside the container
+      "args": ["--endpoint 6", "--PICS /root/matterbridge.pics"], // optional, split on whitespace per entry
+      "input": "y\ny\n", // optional, piped to stdin for tests that prompt for interactive confirmation
+      "resetBefore": true, // optional: clear resetClusterGlobs + restart the container before this test
+      "resetAfter": true, // optional: clear resetClusterGlobs + restart the container after this test (before the next one) — put this on the test that leaves dirty residue, not the one affected by it
+      "skip": true, // optional: list the test (name, comment) but never invoke it — see below
+      "comment": "optional free text, printed under a failing/skipped result in the summary log",
+    },
+  ],
+}
+```
+
+## 4. Mapping the plugin's own endpoint/cluster composition
+
+Every plugin composes its own device tree, so there is no universal endpoint map — discover it fresh for
+each plugin rather than assuming numbers carry over between repos, and re-verify after adding, removing, or
+reordering registered devices. Endpoint 0 is always the root node (`BasicInformation`, not
+`BridgedDeviceBasicInformation` — use `matterbridge.pics`'s `BINFO.*` section there, not `BRBINFO.*`).
+Endpoint 1 is typically the aggregator. Everything above that depends on registration order in the plugin's
+own platform/module code.
+
+To discover which endpoint exposes which cluster, write a throwaway Python script using the same
+`matter.testing` framework the real tests use (it already handles commissioning against the container's
+fixed pairing credentials), copy it into `src/python_testing/` inside the container, run it, then delete it
+— it is not part of the image and must not be left behind:
+
+```python
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+class DumpEndpoints(MatterBaseTest):
+    @async_test_body
+    async def test_dump(self):
+        wildcard = await self.default_controller.ReadAttribute(self.dut_node_id, [()])
+        for ep, clusters in sorted(wildcard.items()):
+            print(f"EP {ep}: {sorted(c.__name__ for c in clusters.keys())}")
+
+if __name__ == "__main__":
+    default_matter_test_main()
+```
+
+The raw `chip-tool` binary (`/root/connectedhomeip/out/host/chip-tool`, run directly rather than through
+`chiptool.py`) is also present, and can reuse the same baked-in pairing at node id `0x12344321` (see §1) —
+but the Python-script approach above is simpler since it reuses the test framework's own commissioning path
+without having to pass `--paa-trust-store-path`/node id by hand on every invocation.
+
+Once discovered, note the endpoint/cluster map for the plugin (e.g. in its own `chipTests.md`) so future
+work doesn't have to rediscover it from scratch — but re-verify before trusting it if the plugin's device
+registration has changed since.
+
+## 5. YAML certification tests vs. Python test files
+
+Not every `TC_<CLUSTER>_<n>_<m>` certification test ID has a corresponding `.py` file in
+`src/python_testing/`. Some certification tests are YAML-only — e.g. for Identify, `TC_I_2_1`/`2_2`/`2_3`
+are YAML-only (`Test_TC_I_2_1.yaml` etc. under `src/app/tests/suites/certification/`), while only
+`TC_I_2_4.py` exists as a Python test. These are not unrunnable — run them as `yamlTests` entries (§3), not
+as a documented gap. Before assuming a test is "missing" from `chipTests.json`, check both:
+
+```shell
+docker exec chip-test bash -c "cd /root/connectedhomeip && timeout 30 python3 scripts/tests/chipyaml/chiptool.py list" | grep -iE 'Test_TC_<CLUSTER>_'
+docker exec chip-test bash -c "ls src/python_testing/ | grep -E '^TC_<CLUSTER>_'"
+```
+
+(prefix with `MSYS_NO_PATHCONV=1` on Windows, see §7) — do not assume a numbering gap is an oversight.
+
+### Running a YAML test manually
+
+```shell
+docker exec -i chip-test python3 scripts/tests/chipyaml/chiptool.py tests Test_TC_I_2_1 --endpoint 7
+```
+
+- Do **not** add `--server_name`/`--server_path`. Left at its default (`server_name='chip-tool'`), the
+  runner resolves the `chip-tool` binary and spawns its own `chip-tool interactive server --port 9002` for
+  the duration of the test, then tears it down — this works cleanly against a freshly-started container.
+  A stray leftover `chip-tool interactive server` process from a killed/timed-out previous invocation (e.g.
+  a shell-level `timeout` that killed the parent but orphaned its spawned child) can end up bound to port
+  9002 and make the _next_ spawn attempt fail with `lws_create_vhost: init server failed` →
+  `CHIP Error 0x000000AC: Internal error`. If that happens, find and kill the orphan
+  (`docker exec chip-test bash -c "ps aux | grep 'chip-tool interactive'"`) rather than working around it
+  with `--server_name ""` — reusing an ad hoc orphaned process is not a documented or supported mode.
+- `tests <TestName>` (no `.yaml` extension) is the subcommand; extra flags after the test name (e.g.
+  `--endpoint 7`) override that test's own `config:` block in the YAML file.
+- `chiptool.py list` prints every runnable YAML test name (individual tests and named collections) — use it
+  to discover what exists for a cluster instead of guessing filenames.
+- The default `--PICS` is the generic `src/app/tests/suites/certification/ci-pics-values` (see §1); pass
+  `--PICS /root/matterbridge.pics` explicitly only if that file has a hand-verified section for the cluster
+  under test — check its content first (and diff step counts with/without it), since an inaccurate section
+  will silently under- or over-skip steps rather than erroring.
+
+### Running a Python test manually
+
+```shell
+docker exec -i chip-test python3 src/python_testing/TC_I_2_4.py --endpoint 7
+```
+
+- No `--commissioning-method`/node-id flags are needed: `matter.testing.runner` falls back to
+  `TestingDefaults.DUT_NODE_ID` (`0x12344321`, the same node id chip-tool's own baked-in pairing uses — see
+  §1) whenever `dut_node_ids`/`commissioning_method` aren't passed explicitly, so the test just reuses the
+  already-commissioned device instead of trying to commission it again.
+- `src/python_testing/<file>.py` (not through `chiptool.py`) is the entry point; extra flags after it (e.g.
+  `--endpoint 7`) map to `chipTests.json`'s `"args"` array for that entry (§3).
+- Pass `--PICS /root/matterbridge.pics` the same way as for YAML tests (see above) when a hand-verified
+  section exists for the cluster under test.
+
+## 6. Test exclusion reasons — do not assume PICS can fix everything
+
+Some certification tests are permanently inapplicable regardless of PICS content, because they are gated by
+something other than a PICS flag:
+
+- `@run_if_endpoint_matches(has_attribute(...))` — probes the **live** attribute list on the real DUT, not
+  PICS. If the attribute genuinely isn't implemented by the plugin/Matterbridge (e.g. `ProductAppearance`),
+  the test always skips.
+- `write_to_app_pipe(...)` / `--app-pipe` — a debug named-pipe protocol only the CSA's own reference
+  `all-clusters-app`/`bridge-app` implements to simulate out-of-band config changes. No real device
+  (including a Matterbridge plugin) can support this.
+- Tests requiring `fabric-sync-app`/`fabric-admin`/`fabric-bridge`/`TH_ICD_SERVER` — an entirely different
+  multi-app test topology, not something `--endpoint` against a single bridge can satisfy.
+
+Check a test's actual gating (`grep -n 'run_if_endpoint_matches\|has_attribute\|app_pipe\|app-pipe' src/python_testing/TC_X.py`
+inside the container) before concluding a PICS change would unlock it.
+
+For a test that's permanently inapplicable for one of the reasons above, set `"skip": true` on its
+`chipTests.json` entry (§3) instead of leaving it to fail on every run. This keeps the entry (name, args,
+`comment` explaining why) in the file for documentation/discoverability, but `runTests()` never invokes it —
+reported as `⏭️` in the summary, excluded from the pass/fail ratio. Don't use `"skip": true` for a real,
+fixable gap (e.g. Known Issues #4/#5/#6 in `chipTests.md`) — only for tests gated on something this harness
+can never provide.
+
+## 7. Windows/Git Bash quoting
+
+Manual `docker exec`/`docker cp` invocations via a POSIX-shell tool on Windows must be prefixed with
+`MSYS_NO_PATHCONV=1`, otherwise Git Bash mangles POSIX-style container paths (e.g. `/root/matterbridge.pics`
+gets translated to a Windows path before reaching `docker`).
+
+## 8. Verifying any change to this harness
+
+After editing `chipTests.json`, `chipTests.md`, `run-chip-tests.mjs`, or `matterbridge.pics` (in the
+`matterbridge` repo), always re-verify end-to-end rather than trusting the edit alone:
+
+1. `node scripts/run-chip-tests.mjs --start`
+2. `node scripts/run-chip-tests.mjs --test <NAME>` for the affected test(s)
+3. `node scripts/run-chip-tests.mjs --stop`
+4. Run the plugin's formatter/linter check on the touched files.
+
+Keep `chipTests.md`'s manual-run shell block and prose in sync with `chipTests.json` whenever tests are
+added, removed, or re-gated on a different PICS file/endpoint.
+
+## 9. CI workflow
+
+`.github/workflows/chip-tests.yml` runs the full suite in CI, but only on demand
+(`workflow_dispatch`, no `push`/`pull_request` trigger) — a full run is dozens of tests and can take tens of
+minutes, and the harness has occasionally shown session/container state leaking between tests (see
+`chipTests.md` Known Issue #4), so it isn't wired into the normal per-PR gate. On a GitHub-hosted
+`ubuntu-latest` runner: Docker Engine is already preinstalled (no setup step needed), and
+`luligu/matterbridge:chip-test` is a modest pull (~260MB compressed per architecture, checked via the Docker
+Hub API), so runner disk space isn't a concern. Every run starts on a fresh runner with no prior
+`chip-test-node-modules` volume (see §1), so `--start` always pays the ~2-3 minute first-run cost — there's
+no way to warm that cache between separate workflow runs. The job mirrors `build.yml`'s matterbridge
+clone/build/`npm link` setup, then goes straight into `--start` → the full test run → `--stop` — no separate
+docker-network step needed, since `--start` itself creates the `matterbridge` network (with `--ipv6`) on a
+fresh runner that doesn't have it yet (see §1). `--stop` runs with `if: always()` so the container always
+gets torn down, even on test failure. No log artifact is uploaded — `chipTests.log`/`chipTestsSummary.log` add nothing the step's own
+console output doesn't already show, since `runTests()` prints every result live. The job fails naturally
+because `run-chip-tests.mjs` sets a nonzero exit code whenever any executed (non-skipped) test fails.

--- a/.agents/plugin-frontend.md
+++ b/.agents/plugin-frontend.md
@@ -1,0 +1,43 @@
+# Matterbridge Plugin Frontend Guide (v.1.0.0)
+
+Use this guide when writing plugin code that interacts with a plugin's own frontend SPA: bundling and serving that SPA and its custom REST API.
+
+This guidance is based on `packages/core/src/frontend.ts` and `packages/core/src/matterbridgePlatform.ts` in the `matterbridge` repository.
+
+## Serving a plugin's bundled frontend SPA
+
+When a plugin package contains a built SPA at `apps/frontend/build/index.html`, `pluginManager.ts` sets `plugin.frontendPath`. Matterbridge then automatically mounts these routes for the plugin:
+
+- `/plugins/<pluginName>/*` serves the plugin's build output as static files.
+- `/plugins/<pluginName>/api/:path` exposes the plugin REST namespace backed by `onFetch`, with JSON body parsing included.
+- `/plugins/<pluginName>/{*splat}` serves the plugin's `index.html` as the SPA fallback for unmatched routes.
+
+A plugin frontend must call its own `/plugins/<pluginName>/api/...` namespace rather than the core `/api/...` endpoints.
+
+## Use `onFetch` for a plugin's custom API
+
+The frontend WebSocket RPC protocol dispatches a fixed set of built-in `/api/...` methods and does not provide a plugin extension point. Override `onFetch` in the platform class when the plugin's frontend needs to communicate with plugin code.
+
+### `onFetch` signature
+
+```ts
+async onFetch(method: string, path?: string, query?: Record<string, unknown>, body?: unknown): Promise<unknown>
+```
+
+Matterbridge calls this method for `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` requests to `/plugins/<pluginName>/api/:path` for every enabled, error-free plugin.
+
+- `method` is the HTTP method.
+- `path` is the `:path` route parameter, such as `'devices'` or `'devices/42'`. It is optional in the TypeScript signature because tests and other code can call `onFetch` directly without a path. Requests through the mounted Express route always provide a non-empty string because `:path` must match at least one segment.
+- `query` contains the query-string parameters.
+- `body` contains the parsed request body for `POST`, `PUT`, and `PATCH` requests.
+- Return a JSON-serializable value. Return `undefined` to produce a `404` response.
+- A thrown error becomes a `500` response with `{ error: 'Internal error in plugin <name>' }`.
+- `DELETE` returns `204` with no response body. Every other method returns `res.json(value)`.
+- If `plugin.platform` is not running, Matterbridge returns `503` without calling `onFetch`.
+
+The base implementation only logs the request and returns `undefined`, so override it to expose real endpoints.
+
+## Avoid unsupported routing patterns
+
+- Do not invent custom WebSocket method names for plugin frontend traffic. The WebSocket dispatch list is fixed; use `onFetch` through `/plugins/<pluginName>/api/...`.
+- Do not call core `/api/...` routes from a plugin's custom frontend. Use the plugin's own `/plugins/<pluginName>/api/...` namespace.

--- a/.claude/rules/chip-tests/chip-tests.instructions.md
+++ b/.claude/rules/chip-tests/chip-tests.instructions.md
@@ -1,0 +1,307 @@
+---
+description: 'How the CHIP conformance test harness works for a Matterbridge plugin (v.1.0.0)'
+paths:
+  - 'chipTests.json'
+  - 'chipTests.md'
+  - 'chipTests.log'
+  - 'chipTestsSummary.log'
+  - 'scripts/run-chip-tests.mjs'
+  - '.github/workflows/chip-tests.yml'
+---
+
+# CHIP Conformance Test Harness
+
+A Matterbridge plugin can be validated against the Matter CHIP certification test suite — both the Python
+test scripts and the YAML certification tests used by the CSA's own CI — running inside the
+`luligu/matterbridge:chip-test` Docker image. The harness is driven entirely by
+`scripts/run-chip-tests.mjs` and configured by `chipTests.json`, both dropped into the plugin repo's root.
+The script is not specific to any one plugin: it reads the plugin name, config, and test list from
+`chipTests.json`, so the same `run-chip-tests.mjs` works unmodified across plugin repos — copy it as-is and
+only author a `chipTests.json` for the new repo.
+
+## 1. What the container is
+
+- Image `luligu/matterbridge:chip-test` bundles a Matterbridge instance plus a full
+  `connectedhomeip`/`chip-tool` checkout with the Python test suite under `src/python_testing/` (relative
+  to the container's default working directory), the YAML certification test suite under
+  `src/app/tests/suites/certification/`, the YAML test runner CLI at
+  `scripts/tests/chipyaml/chiptool.py`, and `chip-tool` itself at `/root/connectedhomeip/out/host/chip-tool`.
+- The container is always named `chip-test` (`containerName` in the script).
+- `chip-tool`'s own persistent storage inside the image already holds a fabric paired with the matterbridge
+  instance, under node id `0x12344321` — this is what makes the YAML tests runnable without a separate
+  commissioning step (see §5). Verified directly: `chip-tool basicinformation read vendor-name 0x12344321 0`
+  reads back `VendorName: Matterbridge` against that existing pairing, no commissioning needed. There is no
+  long-running server process baked into the image; each YAML test invocation spawns its own short-lived
+  `chip-tool interactive server`, runs, and tears it down again.
+- The plugin's `node_modules` (under `/root/Matterbridge/<pluginName>/node_modules`) is shadowed by a named
+  Docker volume (`chip-test-node-modules`), not the host bind mount — this gives the container its own
+  independent, native-Linux-filesystem `node_modules`, since Matterbridge core re-links itself into a local
+  plugin's `node_modules` on every restart when it isn't already there, and running that against a Windows
+  bind mount over Docker Desktop's cross-OS file sharing is dramatically slower (a Windows-created
+  `node_modules/matterbridge` symlink also doesn't reliably resolve from inside the Linux container anyway).
+  The first-ever `--start` has to populate this volume from scratch, comparable to a full `npm install`, so
+  the container can take **2-3 minutes to report ready**; every `--start` after that finds it already
+  populated and skips straight past the re-link, coming up much faster. The named volume persists across
+  `docker rm`/`--start` cycles (only removed by an explicit `docker volume rm chip-test-node-modules`), so
+  this slow first run only happens once per host, not once per `--start`.
+- It runs on the `matterbridge` docker network, mapping the frontend to host port `8585`, mounting `./temp`
+  to `/tmp/matter_testing/logs` (test artifacts) and the plugin repo to `/root/Matterbridge/<pluginName>`,
+  where `<pluginName>` comes from `chipTests.json`'s `config.name`. `start()` creates this network itself
+  (`docker network inspect matterbridge || docker network create --ipv6 matterbridge`) if it doesn't already
+  exist, so a fresh host (including a CI runner, see §9) needs no separate setup step for it. The `--ipv6`
+  flag matters: the container relies on an IPv6 link-local address (e.g. `chip-tool`'s traffic to
+  `fe80::.../UDP:5540`, see §1's `0x12344321` pairing check above), so a plain IPv4-only network breaks it —
+  if the network already exists without `--ipv6` (e.g. created by hand or by another tool), `--start` reuses
+  it as-is rather than recreating it, so that pre-existing network still needs fixing manually.
+- The image bakes in a fixed set of environment variables (`Config.Env` in the Dockerfile, not something
+  `chipTests.json`/`run-chip-tests.mjs` sets — check with `docker inspect luligu/matterbridge:chip-test`).
+  As of this writing that includes `MATTERBRIDGE_CHIP_TEST=1` (a marker flag), `MATTERBRIDGE_START_CONFIGURE_TIMEOUT`/
+  `MATTERBRIDGE_START_REACHABILITY_TIMEOUT` (shorter Matterbridge-core startup timeouts tuned for a fast,
+  local, single-controller container), and one or more plugin-specific opt-in gates (e.g. a var that skips a
+  camera plugin's default-stream self-allocation, or one that switches a WebRTC command handler into strict
+  spec-validation mode instead of a lenient real-controller-friendly default) — these only do anything if
+  the plugin being tested actually reads them via `process.env` and chooses to change behavior accordingly;
+  the image itself doesn't enforce anything. Don't assume a specific plugin implements any of these gates —
+  check that plugin's own source (`process.env.MATTERBRIDGE_*` reads) rather than assuming parity with
+  another plugin, and re-run `docker inspect` for the current list rather than trusting a stale one here.
+- A curated PICS (Protocol Implementation Conformance Statement) file is baked into the image at
+  `/root/matterbridge.pics`, hand-verified against Matterbridge's own default cluster server
+  implementations (see `matterbridge/docker/chip-test/matterbridge.pics` in the `matterbridge` repo — the
+  source lives there, not in the plugin repo). Prefer this file over the generic
+  `src/app/tests/suites/certification/ci-pics-values` (the CSA's own near-blanket CI profile) whenever a
+  hand-verified section exists for the cluster under test — it is what makes tests like
+  `TC_BINFO_*`/`TC_BRBINFO_*` behave correctly instead of asserting on attributes a real device doesn't
+  support. If the cluster you're testing has no section yet in `matterbridge.pics`, either add one there
+  (cross-referencing the Matter spec and the real cluster-server source) or fall back to the generic PICS
+  file for that test.
+
+## 2. Lifecycle commands
+
+```shell
+node scripts/run-chip-tests.mjs --start   # create the container, npm install/link/build, copy the plugin in, matterbridge --add, write config, restart
+node scripts/run-chip-tests.mjs           # run every test in chipTests.json's "yamlTests" and "phytonTests" arrays against the running container
+node scripts/run-chip-tests.mjs --test X  # run only tests whose "name" or "test" (filename) includes X, case-insensitive substring match
+node scripts/run-chip-tests.mjs --stop    # docker stop the container, then npm install/link/build locally to restore the local dev environment
+```
+
+Expose these as `npm run` shortcuts in `package.json`, e.g. `chip:start`, `chip:test`, `chip:test:<cluster>`
+(filtered by the `TC_*` prefix of the test file), `chip:stop`. Add a new `chip:test:<name>` shortcut
+whenever a new cluster's tests are added to `chipTests.json`.
+
+**Always run `--stop` after any container-based investigation.** On Windows especially, `--start`/`--stop`
+swap `node_modules` native binaries (oxlint/oxfmt/tsc addons/etc.) between the container's platform (Linux,
+from the container-side npm install) and the local platform — until `--stop` has run and rebuilt cleanly,
+do not trust local lint/format/typecheck output.
+
+## 3. `chipTests.json` shape
+
+```jsonc
+{
+  "config": {
+    /* the plugin's config.json content, written into the container as
+       /root/.matterbridge/<config.name>.config.json before the final restart in --start.
+       "config.name" is also used as the plugin (npm package) name for the container's
+       volume mount and `matterbridge --add`. */
+  },
+  "resetClusterGlobs": [
+    /* filename globs, matched against files under this plugin's node storage directory for the
+       bridged endpoints, cleared by any test entry that sets "resetBefore": true or
+       "resetAfter": true. Only needs entries for cluster state that's actually persisted to disk —
+       the container restart that "resetBefore"/"resetAfter" also performs already clears any
+       cluster state kept purely in memory, with no glob needed for that. Required (non-empty) if
+       any test uses "resetBefore"/"resetAfter" — the script fails loudly rather than silently
+       skipping the reset if this is empty. */
+  ],
+  "yamlTests": [
+    // optional, defaults to []. "test" is a YAML certification test name (no extension, e.g.
+    // "Test_TC_I_2_1") from src/app/tests/suites/certification/, run via:
+    //   python3 scripts/tests/chipyaml/chiptool.py tests <test.test> <args...>
+    // This spawns a short-lived "chip-tool interactive server" for the duration of the one test, reusing
+    // chip-tool's own persisted fabric pairing baked into the image — see §5. Config values the YAML file
+    // declares (e.g. "endpoint") become CLI flags, so "args": ["--endpoint 6"] overrides the file's own
+    // default. Pass "--PICS /root/matterbridge.pics" in args when a hand-verified section exists for the
+    // cluster under test (see §1) — the tool's own default is the generic ci-pics-values file.
+    // "input"/"resetBefore"/"resetAfter"/"skip"/"comment" (documented on the phytonTests entry below) apply here identically —
+    // run-chip-tests.mjs's runTests() reads them off every entry in yamlTests/phytonTests the same way,
+    // regardless of kind.
+    {
+      "name": "Human-readable label, matched by --test",
+      "test": "Test_TC_SOMETHING_1_2",
+      "args": ["--endpoint 6"],
+      "input": "y\ny\n", // optional, piped to stdin for tests that prompt for interactive confirmation
+      "resetBefore": true, // optional: clear resetClusterGlobs + restart the container before this test
+      "resetAfter": true, // optional: clear resetClusterGlobs + restart the container after this test (before the next one) — put this on the test that leaves dirty residue, not the one affected by it
+      "skip": true, // optional: list the test (name, comment) but never invoke it — see below
+      "comment": "optional free text, printed under a failing/skipped result in the summary log",
+    },
+  ],
+  "phytonTests": [
+    // optional, defaults to [].
+    {
+      "name": "Human-readable label, matched by --test",
+      "test": "TC_SOMETHING_1_2.py", // filename under src/python_testing/ inside the container
+      "args": ["--endpoint 6", "--PICS /root/matterbridge.pics"], // optional, split on whitespace per entry
+      "input": "y\ny\n", // optional, piped to stdin for tests that prompt for interactive confirmation
+      "resetBefore": true, // optional: clear resetClusterGlobs + restart the container before this test
+      "resetAfter": true, // optional: clear resetClusterGlobs + restart the container after this test (before the next one) — put this on the test that leaves dirty residue, not the one affected by it
+      "skip": true, // optional: list the test (name, comment) but never invoke it — see below
+      "comment": "optional free text, printed under a failing/skipped result in the summary log",
+    },
+  ],
+}
+```
+
+## 4. Mapping the plugin's own endpoint/cluster composition
+
+Every plugin composes its own device tree, so there is no universal endpoint map — discover it fresh for
+each plugin rather than assuming numbers carry over between repos, and re-verify after adding, removing, or
+reordering registered devices. Endpoint 0 is always the root node (`BasicInformation`, not
+`BridgedDeviceBasicInformation` — use `matterbridge.pics`'s `BINFO.*` section there, not `BRBINFO.*`).
+Endpoint 1 is typically the aggregator. Everything above that depends on registration order in the plugin's
+own platform/module code.
+
+To discover which endpoint exposes which cluster, write a throwaway Python script using the same
+`matter.testing` framework the real tests use (it already handles commissioning against the container's
+fixed pairing credentials), copy it into `src/python_testing/` inside the container, run it, then delete it
+— it is not part of the image and must not be left behind:
+
+```python
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+class DumpEndpoints(MatterBaseTest):
+    @async_test_body
+    async def test_dump(self):
+        wildcard = await self.default_controller.ReadAttribute(self.dut_node_id, [()])
+        for ep, clusters in sorted(wildcard.items()):
+            print(f"EP {ep}: {sorted(c.__name__ for c in clusters.keys())}")
+
+if __name__ == "__main__":
+    default_matter_test_main()
+```
+
+The raw `chip-tool` binary (`/root/connectedhomeip/out/host/chip-tool`, run directly rather than through
+`chiptool.py`) is also present, and can reuse the same baked-in pairing at node id `0x12344321` (see §1) —
+but the Python-script approach above is simpler since it reuses the test framework's own commissioning path
+without having to pass `--paa-trust-store-path`/node id by hand on every invocation.
+
+Once discovered, note the endpoint/cluster map for the plugin (e.g. in its own `chipTests.md`) so future
+work doesn't have to rediscover it from scratch — but re-verify before trusting it if the plugin's device
+registration has changed since.
+
+## 5. YAML certification tests vs. Python test files
+
+Not every `TC_<CLUSTER>_<n>_<m>` certification test ID has a corresponding `.py` file in
+`src/python_testing/`. Some certification tests are YAML-only — e.g. for Identify, `TC_I_2_1`/`2_2`/`2_3`
+are YAML-only (`Test_TC_I_2_1.yaml` etc. under `src/app/tests/suites/certification/`), while only
+`TC_I_2_4.py` exists as a Python test. These are not unrunnable — run them as `yamlTests` entries (§3), not
+as a documented gap. Before assuming a test is "missing" from `chipTests.json`, check both:
+
+```shell
+docker exec chip-test bash -c "cd /root/connectedhomeip && timeout 30 python3 scripts/tests/chipyaml/chiptool.py list" | grep -iE 'Test_TC_<CLUSTER>_'
+docker exec chip-test bash -c "ls src/python_testing/ | grep -E '^TC_<CLUSTER>_'"
+```
+
+(prefix with `MSYS_NO_PATHCONV=1` on Windows, see §7) — do not assume a numbering gap is an oversight.
+
+### Running a YAML test manually
+
+```shell
+docker exec -i chip-test python3 scripts/tests/chipyaml/chiptool.py tests Test_TC_I_2_1 --endpoint 7
+```
+
+- Do **not** add `--server_name`/`--server_path`. Left at its default (`server_name='chip-tool'`), the
+  runner resolves the `chip-tool` binary and spawns its own `chip-tool interactive server --port 9002` for
+  the duration of the test, then tears it down — this works cleanly against a freshly-started container.
+  A stray leftover `chip-tool interactive server` process from a killed/timed-out previous invocation (e.g.
+  a shell-level `timeout` that killed the parent but orphaned its spawned child) can end up bound to port
+  9002 and make the _next_ spawn attempt fail with `lws_create_vhost: init server failed` →
+  `CHIP Error 0x000000AC: Internal error`. If that happens, find and kill the orphan
+  (`docker exec chip-test bash -c "ps aux | grep 'chip-tool interactive'"`) rather than working around it
+  with `--server_name ""` — reusing an ad hoc orphaned process is not a documented or supported mode.
+- `tests <TestName>` (no `.yaml` extension) is the subcommand; extra flags after the test name (e.g.
+  `--endpoint 7`) override that test's own `config:` block in the YAML file.
+- `chiptool.py list` prints every runnable YAML test name (individual tests and named collections) — use it
+  to discover what exists for a cluster instead of guessing filenames.
+- The default `--PICS` is the generic `src/app/tests/suites/certification/ci-pics-values` (see §1); pass
+  `--PICS /root/matterbridge.pics` explicitly only if that file has a hand-verified section for the cluster
+  under test — check its content first (and diff step counts with/without it), since an inaccurate section
+  will silently under- or over-skip steps rather than erroring.
+
+### Running a Python test manually
+
+```shell
+docker exec -i chip-test python3 src/python_testing/TC_I_2_4.py --endpoint 7
+```
+
+- No `--commissioning-method`/node-id flags are needed: `matter.testing.runner` falls back to
+  `TestingDefaults.DUT_NODE_ID` (`0x12344321`, the same node id chip-tool's own baked-in pairing uses — see
+  §1) whenever `dut_node_ids`/`commissioning_method` aren't passed explicitly, so the test just reuses the
+  already-commissioned device instead of trying to commission it again.
+- `src/python_testing/<file>.py` (not through `chiptool.py`) is the entry point; extra flags after it (e.g.
+  `--endpoint 7`) map to `chipTests.json`'s `"args"` array for that entry (§3).
+- Pass `--PICS /root/matterbridge.pics` the same way as for YAML tests (see above) when a hand-verified
+  section exists for the cluster under test.
+
+## 6. Test exclusion reasons — do not assume PICS can fix everything
+
+Some certification tests are permanently inapplicable regardless of PICS content, because they are gated by
+something other than a PICS flag:
+
+- `@run_if_endpoint_matches(has_attribute(...))` — probes the **live** attribute list on the real DUT, not
+  PICS. If the attribute genuinely isn't implemented by the plugin/Matterbridge (e.g. `ProductAppearance`),
+  the test always skips.
+- `write_to_app_pipe(...)` / `--app-pipe` — a debug named-pipe protocol only the CSA's own reference
+  `all-clusters-app`/`bridge-app` implements to simulate out-of-band config changes. No real device
+  (including a Matterbridge plugin) can support this.
+- Tests requiring `fabric-sync-app`/`fabric-admin`/`fabric-bridge`/`TH_ICD_SERVER` — an entirely different
+  multi-app test topology, not something `--endpoint` against a single bridge can satisfy.
+
+Check a test's actual gating (`grep -n 'run_if_endpoint_matches\|has_attribute\|app_pipe\|app-pipe' src/python_testing/TC_X.py`
+inside the container) before concluding a PICS change would unlock it.
+
+For a test that's permanently inapplicable for one of the reasons above, set `"skip": true` on its
+`chipTests.json` entry (§3) instead of leaving it to fail on every run. This keeps the entry (name, args,
+`comment` explaining why) in the file for documentation/discoverability, but `runTests()` never invokes it —
+reported as `⏭️` in the summary, excluded from the pass/fail ratio. Don't use `"skip": true` for a real,
+fixable gap (e.g. Known Issues #4/#5/#6 in `chipTests.md`) — only for tests gated on something this harness
+can never provide.
+
+## 7. Windows/Git Bash quoting
+
+Manual `docker exec`/`docker cp` invocations via a POSIX-shell tool on Windows must be prefixed with
+`MSYS_NO_PATHCONV=1`, otherwise Git Bash mangles POSIX-style container paths (e.g. `/root/matterbridge.pics`
+gets translated to a Windows path before reaching `docker`).
+
+## 8. Verifying any change to this harness
+
+After editing `chipTests.json`, `chipTests.md`, `run-chip-tests.mjs`, or `matterbridge.pics` (in the
+`matterbridge` repo), always re-verify end-to-end rather than trusting the edit alone:
+
+1. `node scripts/run-chip-tests.mjs --start`
+2. `node scripts/run-chip-tests.mjs --test <NAME>` for the affected test(s)
+3. `node scripts/run-chip-tests.mjs --stop`
+4. Run the plugin's formatter/linter check on the touched files.
+
+Keep `chipTests.md`'s manual-run shell block and prose in sync with `chipTests.json` whenever tests are
+added, removed, or re-gated on a different PICS file/endpoint.
+
+## 9. CI workflow
+
+`.github/workflows/chip-tests.yml` runs the full suite in CI, but only on demand
+(`workflow_dispatch`, no `push`/`pull_request` trigger) — a full run is dozens of tests and can take tens of
+minutes, and the harness has occasionally shown session/container state leaking between tests (see
+`chipTests.md` Known Issue #4), so it isn't wired into the normal per-PR gate. On a GitHub-hosted
+`ubuntu-latest` runner: Docker Engine is already preinstalled (no setup step needed), and
+`luligu/matterbridge:chip-test` is a modest pull (~260MB compressed per architecture, checked via the Docker
+Hub API), so runner disk space isn't a concern. Every run starts on a fresh runner with no prior
+`chip-test-node-modules` volume (see §1), so `--start` always pays the ~2-3 minute first-run cost — there's
+no way to warm that cache between separate workflow runs. The job mirrors `build.yml`'s matterbridge
+clone/build/`npm link` setup, then goes straight into `--start` → the full test run → `--stop` — no separate
+docker-network step needed, since `--start` itself creates the `matterbridge` network (with `--ipv6`) on a
+fresh runner that doesn't have it yet (see §1). `--stop` runs with `if: always()` so the container always
+gets torn down, even on test failure. No log artifact is uploaded — `chipTests.log`/`chipTestsSummary.log` add nothing the step's own
+console output doesn't already show, since `runTests()` prints every result live. The job fails naturally
+because `run-chip-tests.mjs` sets a nonzero exit code whenever any executed (non-skipped) test fails.

--- a/.claude/rules/plugin-frontend/plugin-frontend.instructions.md
+++ b/.claude/rules/plugin-frontend/plugin-frontend.instructions.md
@@ -1,0 +1,50 @@
+---
+description: 'How a plugin serves its own frontend SPA and custom REST API via onFetch (v.1.0.0)'
+paths:
+  - 'apps/frontend/**'
+  - 'src/*.ts'
+---
+
+# Matterbridge Plugin Frontend Guide
+
+Use this guide when writing plugin code that interacts with a plugin's own frontend SPA: bundling and serving that SPA and its custom REST API.
+
+This guide is based on `packages/core/src/frontend.ts` and `packages/core/src/matterbridgePlatform.ts` in the `matterbridge` repository.
+
+## Serving a plugin's own bundled frontend SPA
+
+If the plugin package ships a built SPA at `apps/frontend/build/index.html`, `pluginManager.ts` sets `plugin.frontendPath` and Matterbridge automatically mounts, per plugin:
+
+- `/plugins/<pluginName>/*` — static hosting of the plugin's build output.
+- `/plugins/<pluginName>/api/:path` — the `onFetch`-backed REST namespace described below (JSON body parsing included).
+- `/plugins/<pluginName>/{*splat}` — SPA fallback serving the plugin's own `index.html` for unmatched routes.
+
+A plugin's own frontend should call its own namespace (`/plugins/<pluginName>/api/...`), not the core `/api/...` endpoints.
+
+## The plugin-extensible hook: `onFetch`
+
+The frontend's WebSocket RPC protocol is a fixed dispatch of built-in `/api/...` methods, and it has no plugin extension point. The one method that hands control back to plugin code for a plugin's own frontend is `onFetch`, declared on `MatterbridgePlatform` and meant to be overridden in your platform class.
+
+### `onFetch` — custom plugin REST API
+
+```ts
+async onFetch(method: string, path?: string, query?: Record<string, unknown>, body?: unknown): Promise<unknown>
+```
+
+Called by the Matterbridge frontend for plugin API requests. Reached via `GET|POST|PUT|PATCH|DELETE /plugins/<pluginName>/api/:path`, mounted automatically for every enabled, error-free plugin.
+
+- `method` — HTTP method.
+- `path` — the `:path` route param (e.g. `'devices'`, `'devices/42'`). Typed optional on `onFetch` because the method can be called directly (e.g. in tests) without one; via the real mounted route it is always a defined string, since Express requires `:path` to match at least one segment.
+- `query` — query string parameters.
+- `body` — request body (`POST`/`PUT`/`PATCH`).
+- Return a JSON-serializable value, or `undefined` to respond with **404**.
+- A thrown error becomes a **500** `{ error: 'Internal error in plugin <name>' }`.
+- `DELETE` responds **204** with no body; every other method responds `res.json(value)`.
+- If `plugin.platform` isn't running yet, the frontend returns **503** before calling `onFetch`.
+
+The default base-class implementation logs and returns `undefined` (404) — override it to expose real endpoints.
+
+## Avoid these mistakes
+
+- Do not invent a custom WebSocket method name expecting the frontend to route to it — the WS dispatch is a fixed core method list with no plugin extension point. Use `onFetch` under `/plugins/<pluginName>/api/...` for a plugin's own frontend traffic.
+- Do not build a plugin's custom frontend to call core `/api/...` routes — use `/plugins/<pluginName>/api/...`, backed by your own `onFetch`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "_comment": "Claude settings v. 1.0.5",
+  "_comment": "Claude settings v. 1.0.6",
   "permissions": {
     "deny": [
       "Read(.env)",
@@ -18,6 +18,7 @@
       "Bash(git branch -D:*)",
       "Bash(git branch -d:*)",
       "Bash(git tag -d:*)",
+      "Bash(git stash:*)",
       "Bash(git reflog expire:*)",
       "Bash(git reflog delete:*)"
     ],

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,11 +1,11 @@
-# Codex config v.1.0.2
+# Codex config v.1.0.3
 
 approval_policy = "on-request"
 approvals_reviewer = "user"
 
 web_search = "live"
 
-default_permissions = "matterbridge_safe"
+default_permissions = ":workspace"
 
 [shell_environment_policy]
 inherit = "core"

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,4 +1,4 @@
-# Codex rules v.1.0.1
+# Codex rules v.1.0.2
 
 # Git mutations
 prefix_rule(pattern = ["git", "pull"], decision = "forbidden", justification = "Do not change local refs without explicit manual control.")

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,19 +1,18 @@
-# Codex rules v.1.0.2
+# Codex rules v.1.0.3
 
 # Git mutations
-prefix_rule(pattern = ["git", "pull"], decision = "forbidden", justification = "Do not change local refs without explicit manual control.")
-prefix_rule(pattern = ["git", "merge"], decision = "forbidden", justification = "Do not merge automatically.")
-prefix_rule(pattern = ["git", "push"], decision = "forbidden", justification = "Do not push automatically.")
-prefix_rule(pattern = ["git", "rebase"], decision = "forbidden", justification = "Do not rewrite branch history automatically.")
-prefix_rule(pattern = ["git", "commit"], decision = "forbidden", justification = "Do not create commits automatically.")
-prefix_rule(pattern = ["git", "commit", "--amend"], decision = "forbidden", justification = "Do not amend commits automatically.")
-prefix_rule(pattern = ["git", "reset", "--hard"], decision = "forbidden", justification = "Destructive reset is blocked.")
-prefix_rule(pattern = ["git", "filter-branch"], decision = "forbidden", justification = "History rewriting is blocked.")
-prefix_rule(pattern = ["git", "branch", "-D"], decision = "forbidden", justification = "Branch deletion is blocked.")
-prefix_rule(pattern = ["git", "branch", "-d"], decision = "forbidden", justification = "Branch deletion is blocked.")
-prefix_rule(pattern = ["git", "tag", "-d"], decision = "forbidden", justification = "Tag deletion is blocked.")
-prefix_rule(pattern = ["git", "reflog", "expire"], decision = "forbidden", justification = "Reflog mutation is blocked.")
-prefix_rule(pattern = ["git", "reflog", "delete"], decision = "forbidden", justification = "Reflog mutation is blocked.")
+prefix_rule(pattern = ["git", "pull"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "merge"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "push"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "rebase"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "commit"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "reset"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "filter-branch"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "branch", "-D"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "branch", "-d"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "tag", "-d"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "reflog", "expire"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
+prefix_rule(pattern = ["git", "reflog", "delete"], decision = "forbidden", justification = "This command must be run manually outside Codex.")
 
 # Dependency installs
 prefix_rule(pattern = ["npm", "install"], decision = "prompt", justification = "Ask before installing dependencies.")
@@ -26,7 +25,6 @@ prefix_rule(pattern = ["bun", "add"], decision = "prompt", justification = "Ask 
 prefix_rule(pattern = ["bun", "remove"], decision = "prompt", justification = "Ask before uninstalling dependencies.")
 
 # Validation scripts
-prefix_rule(pattern = ["npm", "run"], decision = "allow")
 prefix_rule(pattern = ["npm", "run", "typecheck"], decision = "allow")
 prefix_rule(pattern = ["npm", "run", "build"], decision = "allow")
 prefix_rule(pattern = ["npm", "run", "test"], decision = "allow")

--- a/.github/instructions/chip-tests/chip-tests.instructions.md
+++ b/.github/instructions/chip-tests/chip-tests.instructions.md
@@ -1,0 +1,302 @@
+---
+name: 'CHIP Conformance Test Harness v.1.0.0'
+description: 'How the CHIP conformance test harness works for a Matterbridge plugin'
+applyTo: 'chipTests.json, chipTests.md, chipTests.log, chipTestsSummary.log, scripts/run-chip-tests.mjs, .github/workflows/chip-tests.yml'
+---
+
+# CHIP Conformance Test Harness
+
+A Matterbridge plugin can be validated against the Matter CHIP certification test suite — both the Python
+test scripts and the YAML certification tests used by the CSA's own CI — running inside the
+`luligu/matterbridge:chip-test` Docker image. The harness is driven entirely by
+`scripts/run-chip-tests.mjs` and configured by `chipTests.json`, both dropped into the plugin repo's root.
+The script is not specific to any one plugin: it reads the plugin name, config, and test list from
+`chipTests.json`, so the same `run-chip-tests.mjs` works unmodified across plugin repos — copy it as-is and
+only author a `chipTests.json` for the new repo.
+
+## 1. What the container is
+
+- Image `luligu/matterbridge:chip-test` bundles a Matterbridge instance plus a full
+  `connectedhomeip`/`chip-tool` checkout with the Python test suite under `src/python_testing/` (relative
+  to the container's default working directory), the YAML certification test suite under
+  `src/app/tests/suites/certification/`, the YAML test runner CLI at
+  `scripts/tests/chipyaml/chiptool.py`, and `chip-tool` itself at `/root/connectedhomeip/out/host/chip-tool`.
+- The container is always named `chip-test` (`containerName` in the script).
+- `chip-tool`'s own persistent storage inside the image already holds a fabric paired with the matterbridge
+  instance, under node id `0x12344321` — this is what makes the YAML tests runnable without a separate
+  commissioning step (see §5). Verified directly: `chip-tool basicinformation read vendor-name 0x12344321 0`
+  reads back `VendorName: Matterbridge` against that existing pairing, no commissioning needed. There is no
+  long-running server process baked into the image; each YAML test invocation spawns its own short-lived
+  `chip-tool interactive server`, runs, and tears it down again.
+- The plugin's `node_modules` (under `/root/Matterbridge/<pluginName>/node_modules`) is shadowed by a named
+  Docker volume (`chip-test-node-modules`), not the host bind mount — this gives the container its own
+  independent, native-Linux-filesystem `node_modules`, since Matterbridge core re-links itself into a local
+  plugin's `node_modules` on every restart when it isn't already there, and running that against a Windows
+  bind mount over Docker Desktop's cross-OS file sharing is dramatically slower (a Windows-created
+  `node_modules/matterbridge` symlink also doesn't reliably resolve from inside the Linux container anyway).
+  The first-ever `--start` has to populate this volume from scratch, comparable to a full `npm install`, so
+  the container can take **2-3 minutes to report ready**; every `--start` after that finds it already
+  populated and skips straight past the re-link, coming up much faster. The named volume persists across
+  `docker rm`/`--start` cycles (only removed by an explicit `docker volume rm chip-test-node-modules`), so
+  this slow first run only happens once per host, not once per `--start`.
+- It runs on the `matterbridge` docker network, mapping the frontend to host port `8585`, mounting `./temp`
+  to `/tmp/matter_testing/logs` (test artifacts) and the plugin repo to `/root/Matterbridge/<pluginName>`,
+  where `<pluginName>` comes from `chipTests.json`'s `config.name`. `start()` creates this network itself
+  (`docker network inspect matterbridge || docker network create --ipv6 matterbridge`) if it doesn't already
+  exist, so a fresh host (including a CI runner, see §9) needs no separate setup step for it. The `--ipv6`
+  flag matters: the container relies on an IPv6 link-local address (e.g. `chip-tool`'s traffic to
+  `fe80::.../UDP:5540`, see §1's `0x12344321` pairing check above), so a plain IPv4-only network breaks it —
+  if the network already exists without `--ipv6` (e.g. created by hand or by another tool), `--start` reuses
+  it as-is rather than recreating it, so that pre-existing network still needs fixing manually.
+- The image bakes in a fixed set of environment variables (`Config.Env` in the Dockerfile, not something
+  `chipTests.json`/`run-chip-tests.mjs` sets — check with `docker inspect luligu/matterbridge:chip-test`).
+  As of this writing that includes `MATTERBRIDGE_CHIP_TEST=1` (a marker flag), `MATTERBRIDGE_START_CONFIGURE_TIMEOUT`/
+  `MATTERBRIDGE_START_REACHABILITY_TIMEOUT` (shorter Matterbridge-core startup timeouts tuned for a fast,
+  local, single-controller container), and one or more plugin-specific opt-in gates (e.g. a var that skips a
+  camera plugin's default-stream self-allocation, or one that switches a WebRTC command handler into strict
+  spec-validation mode instead of a lenient real-controller-friendly default) — these only do anything if
+  the plugin being tested actually reads them via `process.env` and chooses to change behavior accordingly;
+  the image itself doesn't enforce anything. Don't assume a specific plugin implements any of these gates —
+  check that plugin's own source (`process.env.MATTERBRIDGE_*` reads) rather than assuming parity with
+  another plugin, and re-run `docker inspect` for the current list rather than trusting a stale one here.
+- A curated PICS (Protocol Implementation Conformance Statement) file is baked into the image at
+  `/root/matterbridge.pics`, hand-verified against Matterbridge's own default cluster server
+  implementations (see `matterbridge/docker/chip-test/matterbridge.pics` in the `matterbridge` repo — the
+  source lives there, not in the plugin repo). Prefer this file over the generic
+  `src/app/tests/suites/certification/ci-pics-values` (the CSA's own near-blanket CI profile) whenever a
+  hand-verified section exists for the cluster under test — it is what makes tests like
+  `TC_BINFO_*`/`TC_BRBINFO_*` behave correctly instead of asserting on attributes a real device doesn't
+  support. If the cluster you're testing has no section yet in `matterbridge.pics`, either add one there
+  (cross-referencing the Matter spec and the real cluster-server source) or fall back to the generic PICS
+  file for that test.
+
+## 2. Lifecycle commands
+
+```shell
+node scripts/run-chip-tests.mjs --start   # create the container, npm install/link/build, copy the plugin in, matterbridge --add, write config, restart
+node scripts/run-chip-tests.mjs           # run every test in chipTests.json's "yamlTests" and "phytonTests" arrays against the running container
+node scripts/run-chip-tests.mjs --test X  # run only tests whose "name" or "test" (filename) includes X, case-insensitive substring match
+node scripts/run-chip-tests.mjs --stop    # docker stop the container, then npm install/link/build locally to restore the local dev environment
+```
+
+Expose these as `npm run` shortcuts in `package.json`, e.g. `chip:start`, `chip:test`, `chip:test:<cluster>`
+(filtered by the `TC_*` prefix of the test file), `chip:stop`. Add a new `chip:test:<name>` shortcut
+whenever a new cluster's tests are added to `chipTests.json`.
+
+**Always run `--stop` after any container-based investigation.** On Windows especially, `--start`/`--stop`
+swap `node_modules` native binaries (oxlint/oxfmt/tsc addons/etc.) between the container's platform (Linux,
+from the container-side npm install) and the local platform — until `--stop` has run and rebuilt cleanly,
+do not trust local lint/format/typecheck output.
+
+## 3. `chipTests.json` shape
+
+```jsonc
+{
+  "config": {
+    /* the plugin's config.json content, written into the container as
+       /root/.matterbridge/<config.name>.config.json before the final restart in --start.
+       "config.name" is also used as the plugin (npm package) name for the container's
+       volume mount and `matterbridge --add`. */
+  },
+  "resetClusterGlobs": [
+    /* filename globs, matched against files under this plugin's node storage directory for the
+       bridged endpoints, cleared by any test entry that sets "resetBefore": true or
+       "resetAfter": true. Only needs entries for cluster state that's actually persisted to disk —
+       the container restart that "resetBefore"/"resetAfter" also performs already clears any
+       cluster state kept purely in memory, with no glob needed for that. Required (non-empty) if
+       any test uses "resetBefore"/"resetAfter" — the script fails loudly rather than silently
+       skipping the reset if this is empty. */
+  ],
+  "yamlTests": [
+    // optional, defaults to []. "test" is a YAML certification test name (no extension, e.g.
+    // "Test_TC_I_2_1") from src/app/tests/suites/certification/, run via:
+    //   python3 scripts/tests/chipyaml/chiptool.py tests <test.test> <args...>
+    // This spawns a short-lived "chip-tool interactive server" for the duration of the one test, reusing
+    // chip-tool's own persisted fabric pairing baked into the image — see §5. Config values the YAML file
+    // declares (e.g. "endpoint") become CLI flags, so "args": ["--endpoint 6"] overrides the file's own
+    // default. Pass "--PICS /root/matterbridge.pics" in args when a hand-verified section exists for the
+    // cluster under test (see §1) — the tool's own default is the generic ci-pics-values file.
+    // "input"/"resetBefore"/"resetAfter"/"skip"/"comment" (documented on the phytonTests entry below) apply here identically —
+    // run-chip-tests.mjs's runTests() reads them off every entry in yamlTests/phytonTests the same way,
+    // regardless of kind.
+    {
+      "name": "Human-readable label, matched by --test",
+      "test": "Test_TC_SOMETHING_1_2",
+      "args": ["--endpoint 6"],
+      "input": "y\ny\n", // optional, piped to stdin for tests that prompt for interactive confirmation
+      "resetBefore": true, // optional: clear resetClusterGlobs + restart the container before this test
+      "resetAfter": true, // optional: clear resetClusterGlobs + restart the container after this test (before the next one) — put this on the test that leaves dirty residue, not the one affected by it
+      "skip": true, // optional: list the test (name, comment) but never invoke it — see below
+      "comment": "optional free text, printed under a failing/skipped result in the summary log",
+    },
+  ],
+  "phytonTests": [
+    // optional, defaults to [].
+    {
+      "name": "Human-readable label, matched by --test",
+      "test": "TC_SOMETHING_1_2.py", // filename under src/python_testing/ inside the container
+      "args": ["--endpoint 6", "--PICS /root/matterbridge.pics"], // optional, split on whitespace per entry
+      "input": "y\ny\n", // optional, piped to stdin for tests that prompt for interactive confirmation
+      "resetBefore": true, // optional: clear resetClusterGlobs + restart the container before this test
+      "resetAfter": true, // optional: clear resetClusterGlobs + restart the container after this test (before the next one) — put this on the test that leaves dirty residue, not the one affected by it
+      "skip": true, // optional: list the test (name, comment) but never invoke it — see below
+      "comment": "optional free text, printed under a failing/skipped result in the summary log",
+    },
+  ],
+}
+```
+
+## 4. Mapping the plugin's own endpoint/cluster composition
+
+Every plugin composes its own device tree, so there is no universal endpoint map — discover it fresh for
+each plugin rather than assuming numbers carry over between repos, and re-verify after adding, removing, or
+reordering registered devices. Endpoint 0 is always the root node (`BasicInformation`, not
+`BridgedDeviceBasicInformation` — use `matterbridge.pics`'s `BINFO.*` section there, not `BRBINFO.*`).
+Endpoint 1 is typically the aggregator. Everything above that depends on registration order in the plugin's
+own platform/module code.
+
+To discover which endpoint exposes which cluster, write a throwaway Python script using the same
+`matter.testing` framework the real tests use (it already handles commissioning against the container's
+fixed pairing credentials), copy it into `src/python_testing/` inside the container, run it, then delete it
+— it is not part of the image and must not be left behind:
+
+```python
+import matter.clusters as Clusters
+from matter.testing.decorators import async_test_body
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import default_matter_test_main
+
+class DumpEndpoints(MatterBaseTest):
+    @async_test_body
+    async def test_dump(self):
+        wildcard = await self.default_controller.ReadAttribute(self.dut_node_id, [()])
+        for ep, clusters in sorted(wildcard.items()):
+            print(f"EP {ep}: {sorted(c.__name__ for c in clusters.keys())}")
+
+if __name__ == "__main__":
+    default_matter_test_main()
+```
+
+The raw `chip-tool` binary (`/root/connectedhomeip/out/host/chip-tool`, run directly rather than through
+`chiptool.py`) is also present, and can reuse the same baked-in pairing at node id `0x12344321` (see §1) —
+but the Python-script approach above is simpler since it reuses the test framework's own commissioning path
+without having to pass `--paa-trust-store-path`/node id by hand on every invocation.
+
+Once discovered, note the endpoint/cluster map for the plugin (e.g. in its own `chipTests.md`) so future
+work doesn't have to rediscover it from scratch — but re-verify before trusting it if the plugin's device
+registration has changed since.
+
+## 5. YAML certification tests vs. Python test files
+
+Not every `TC_<CLUSTER>_<n>_<m>` certification test ID has a corresponding `.py` file in
+`src/python_testing/`. Some certification tests are YAML-only — e.g. for Identify, `TC_I_2_1`/`2_2`/`2_3`
+are YAML-only (`Test_TC_I_2_1.yaml` etc. under `src/app/tests/suites/certification/`), while only
+`TC_I_2_4.py` exists as a Python test. These are not unrunnable — run them as `yamlTests` entries (§3), not
+as a documented gap. Before assuming a test is "missing" from `chipTests.json`, check both:
+
+```shell
+docker exec chip-test bash -c "cd /root/connectedhomeip && timeout 30 python3 scripts/tests/chipyaml/chiptool.py list" | grep -iE 'Test_TC_<CLUSTER>_'
+docker exec chip-test bash -c "ls src/python_testing/ | grep -E '^TC_<CLUSTER>_'"
+```
+
+(prefix with `MSYS_NO_PATHCONV=1` on Windows, see §7) — do not assume a numbering gap is an oversight.
+
+### Running a YAML test manually
+
+```shell
+docker exec -i chip-test python3 scripts/tests/chipyaml/chiptool.py tests Test_TC_I_2_1 --endpoint 7
+```
+
+- Do **not** add `--server_name`/`--server_path`. Left at its default (`server_name='chip-tool'`), the
+  runner resolves the `chip-tool` binary and spawns its own `chip-tool interactive server --port 9002` for
+  the duration of the test, then tears it down — this works cleanly against a freshly-started container.
+  A stray leftover `chip-tool interactive server` process from a killed/timed-out previous invocation (e.g.
+  a shell-level `timeout` that killed the parent but orphaned its spawned child) can end up bound to port
+  9002 and make the _next_ spawn attempt fail with `lws_create_vhost: init server failed` →
+  `CHIP Error 0x000000AC: Internal error`. If that happens, find and kill the orphan
+  (`docker exec chip-test bash -c "ps aux | grep 'chip-tool interactive'"`) rather than working around it
+  with `--server_name ""` — reusing an ad hoc orphaned process is not a documented or supported mode.
+- `tests <TestName>` (no `.yaml` extension) is the subcommand; extra flags after the test name (e.g.
+  `--endpoint 7`) override that test's own `config:` block in the YAML file.
+- `chiptool.py list` prints every runnable YAML test name (individual tests and named collections) — use it
+  to discover what exists for a cluster instead of guessing filenames.
+- The default `--PICS` is the generic `src/app/tests/suites/certification/ci-pics-values` (see §1); pass
+  `--PICS /root/matterbridge.pics` explicitly only if that file has a hand-verified section for the cluster
+  under test — check its content first (and diff step counts with/without it), since an inaccurate section
+  will silently under- or over-skip steps rather than erroring.
+
+### Running a Python test manually
+
+```shell
+docker exec -i chip-test python3 src/python_testing/TC_I_2_4.py --endpoint 7
+```
+
+- No `--commissioning-method`/node-id flags are needed: `matter.testing.runner` falls back to
+  `TestingDefaults.DUT_NODE_ID` (`0x12344321`, the same node id chip-tool's own baked-in pairing uses — see
+  §1) whenever `dut_node_ids`/`commissioning_method` aren't passed explicitly, so the test just reuses the
+  already-commissioned device instead of trying to commission it again.
+- `src/python_testing/<file>.py` (not through `chiptool.py`) is the entry point; extra flags after it (e.g.
+  `--endpoint 7`) map to `chipTests.json`'s `"args"` array for that entry (§3).
+- Pass `--PICS /root/matterbridge.pics` the same way as for YAML tests (see above) when a hand-verified
+  section exists for the cluster under test.
+
+## 6. Test exclusion reasons — do not assume PICS can fix everything
+
+Some certification tests are permanently inapplicable regardless of PICS content, because they are gated by
+something other than a PICS flag:
+
+- `@run_if_endpoint_matches(has_attribute(...))` — probes the **live** attribute list on the real DUT, not
+  PICS. If the attribute genuinely isn't implemented by the plugin/Matterbridge (e.g. `ProductAppearance`),
+  the test always skips.
+- `write_to_app_pipe(...)` / `--app-pipe` — a debug named-pipe protocol only the CSA's own reference
+  `all-clusters-app`/`bridge-app` implements to simulate out-of-band config changes. No real device
+  (including a Matterbridge plugin) can support this.
+- Tests requiring `fabric-sync-app`/`fabric-admin`/`fabric-bridge`/`TH_ICD_SERVER` — an entirely different
+  multi-app test topology, not something `--endpoint` against a single bridge can satisfy.
+
+Check a test's actual gating (`grep -n 'run_if_endpoint_matches\|has_attribute\|app_pipe\|app-pipe' src/python_testing/TC_X.py`
+inside the container) before concluding a PICS change would unlock it.
+
+For a test that's permanently inapplicable for one of the reasons above, set `"skip": true` on its
+`chipTests.json` entry (§3) instead of leaving it to fail on every run. This keeps the entry (name, args,
+`comment` explaining why) in the file for documentation/discoverability, but `runTests()` never invokes it —
+reported as `⏭️` in the summary, excluded from the pass/fail ratio. Don't use `"skip": true` for a real,
+fixable gap (e.g. Known Issues #4/#5/#6 in `chipTests.md`) — only for tests gated on something this harness
+can never provide.
+
+## 7. Windows/Git Bash quoting
+
+Manual `docker exec`/`docker cp` invocations via a POSIX-shell tool on Windows must be prefixed with
+`MSYS_NO_PATHCONV=1`, otherwise Git Bash mangles POSIX-style container paths (e.g. `/root/matterbridge.pics`
+gets translated to a Windows path before reaching `docker`).
+
+## 8. Verifying any change to this harness
+
+After editing `chipTests.json`, `chipTests.md`, `run-chip-tests.mjs`, or `matterbridge.pics` (in the
+`matterbridge` repo), always re-verify end-to-end rather than trusting the edit alone:
+
+1. `node scripts/run-chip-tests.mjs --start`
+2. `node scripts/run-chip-tests.mjs --test <NAME>` for the affected test(s)
+3. `node scripts/run-chip-tests.mjs --stop`
+4. Run the plugin's formatter/linter check on the touched files.
+
+Keep `chipTests.md`'s manual-run shell block and prose in sync with `chipTests.json` whenever tests are
+added, removed, or re-gated on a different PICS file/endpoint.
+
+## 9. CI workflow
+
+`.github/workflows/chip-tests.yml` runs the full suite in CI, but only on demand
+(`workflow_dispatch`, no `push`/`pull_request` trigger) — a full run is dozens of tests and can take tens of
+minutes, and the harness has occasionally shown session/container state leaking between tests (see
+`chipTests.md` Known Issue #4), so it isn't wired into the normal per-PR gate. On a GitHub-hosted
+`ubuntu-latest` runner: Docker Engine is already preinstalled (no setup step needed), and
+`luligu/matterbridge:chip-test` is a modest pull (~260MB compressed per architecture, checked via the Docker
+Hub API), so runner disk space isn't a concern. Every run starts on a fresh runner with no prior
+`chip-test-node-modules` volume (see §1), so `--start` always pays the ~2-3 minute first-run cost — there's
+no way to warm that cache between separate workflow runs. The job mirrors `build.yml`'s matterbridge
+clone/build/`npm link` setup, then goes straight into `--start` → the full test run → `--stop` — no separate
+docker-network step needed, since `--start` itself creates the `matterbridge` network (with `--ipv6`) on a
+fresh runner that doesn't have it yet (see §1). `--stop` runs with `if: always()` so the container always
+gets torn down, even on test failure. No log artifact is uploaded — `chipTests.log`/`chipTestsSummary.log` add nothing the step's own
+console output doesn't already show, since `runTests()` prints every result live. The job fails naturally
+because `run-chip-tests.mjs` sets a nonzero exit code whenever any executed (non-skipped) test fails.

--- a/.github/instructions/plugin-frontend/plugin-frontend.instructions.md
+++ b/.github/instructions/plugin-frontend/plugin-frontend.instructions.md
@@ -1,0 +1,49 @@
+---
+name: 'Matterbridge Plugin Frontend Guide v.1.0.0'
+description: 'How a plugin serves its own frontend SPA and custom REST API via onFetch'
+applyTo: 'apps/frontend/**, src/*.ts'
+---
+
+# Matterbridge Plugin Frontend Guide
+
+Use this guide when writing plugin code that interacts with a plugin's own frontend SPA: bundling and serving that SPA and its custom REST API.
+
+This guide is based on `packages/core/src/frontend.ts` and `packages/core/src/matterbridgePlatform.ts` in the `matterbridge` repository.
+
+## Serving a plugin's own bundled frontend SPA
+
+If the plugin package ships a built SPA at `apps/frontend/build/index.html`, `pluginManager.ts` sets `plugin.frontendPath` and Matterbridge automatically mounts, per plugin:
+
+- `/plugins/<pluginName>/*` — static hosting of the plugin's build output.
+- `/plugins/<pluginName>/api/:path` — the `onFetch`-backed REST namespace described below (JSON body parsing included).
+- `/plugins/<pluginName>/{*splat}` — SPA fallback serving the plugin's own `index.html` for unmatched routes.
+
+A plugin's own frontend should call its own namespace (`/plugins/<pluginName>/api/...`), not the core `/api/...` endpoints.
+
+## The plugin-extensible hook: `onFetch`
+
+The frontend's WebSocket RPC protocol is a fixed dispatch of built-in `/api/...` methods, and it has no plugin extension point. The one method that hands control back to plugin code for a plugin's own frontend is `onFetch`, declared on `MatterbridgePlatform` and meant to be overridden in your platform class.
+
+### `onFetch` — custom plugin REST API
+
+```ts
+async onFetch(method: string, path?: string, query?: Record<string, unknown>, body?: unknown): Promise<unknown>
+```
+
+Called by the Matterbridge frontend for plugin API requests. Reached via `GET|POST|PUT|PATCH|DELETE /plugins/<pluginName>/api/:path`, mounted automatically for every enabled, error-free plugin.
+
+- `method` — HTTP method.
+- `path` — the `:path` route param (e.g. `'devices'`, `'devices/42'`). Typed optional on `onFetch` because the method can be called directly (e.g. in tests) without one; via the real mounted route it is always a defined string, since Express requires `:path` to match at least one segment.
+- `query` — query string parameters.
+- `body` — request body (`POST`/`PUT`/`PATCH`).
+- Return a JSON-serializable value, or `undefined` to respond with **404**.
+- A thrown error becomes a **500** `{ error: 'Internal error in plugin <name>' }`.
+- `DELETE` responds **204** with no body; every other method responds `res.json(value)`.
+- If `plugin.platform` isn't running yet, the frontend returns **503** before calling `onFetch`.
+
+The default base-class implementation logs and returns `undefined` (404) — override it to expose real endpoints.
+
+## Avoid these mistakes
+
+- Do not invent a custom WebSocket method name expecting the frontend to route to it — the WS dispatch is a fixed core method list with no plugin extension point. Use `onFetch` under `/plugins/<pluginName>/api/...` for a plugin's own frontend traffic.
+- Do not build a plugin's custom frontend to call core `/api/...` routes — use `/plugins/<pluginName>/api/...`, backed by your own `onFetch`.

--- a/.github/workflows/chip-tests.yml
+++ b/.github/workflows/chip-tests.yml
@@ -1,0 +1,52 @@
+# CHIP conformance test suite (on demand) v.1.0.0
+# Path: .github/workflows/chip-tests.yml
+
+name: CHIP conformance tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  chip-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Clone matterbridge repo (dev branch)
+        run: git clone --depth 1 --single-branch --no-tags -b dev https://github.com/Luligu/matterbridge.git ../matterbridge
+
+      - name: Install matterbridge dependencies
+        working-directory: ../matterbridge
+        run: npm ci --no-fund --no-audit
+
+      - name: Build matterbridge
+        working-directory: ../matterbridge
+        run: npm run build
+
+      - name: Link matterbridge globally
+        working-directory: ../matterbridge
+        run: npm link --no-fund --no-audit
+
+      - name: Install plugin dependencies
+        run: npm ci --no-fund --no-audit
+
+      - name: Link matterbridge in the plugin
+        run: npm link matterbridge --no-fund --no-audit
+
+      - name: Start the chip-test container
+        run: node scripts/run-chip-tests.mjs --start
+
+      - name: Run the full CHIP test suite
+        run: node scripts/run-chip-tests.mjs
+
+      - name: Stop the chip-test container
+        if: always()
+        run: node scripts/run-chip-tests.mjs --stop

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,4 +1,4 @@
-// .oxlintrc.json 1.0.17
+// .oxlintrc.json 1.0.18
 
 // This Oxlint configuration (shared between all matterbridge packages) is designed for a TypeScript project using ESM modules.
 {
@@ -119,6 +119,7 @@
       }
     ],
     "node/no-process-env": "off", // Accessing environment variables is common and not a problem in this project
+    "node/no-top-level-await": "off", // The Matterbridge ecosystem is pure ESM (no "require" export condition anywhere), so there are no require(esm) consumers this rule would protect
     "jsdoc/check-tag-names": ["warn", { "definedTags": ["created", "contributor", "remarks"] }],
     "jsdoc/require-param": "warn",
     "jsdoc/require-param-type": "warn",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,5 @@ For task-specific guidance, read relevant files in [.agents](./.agents/):
 
 - `.agents/testing.md` for testing and validation expectations;
 - `.agents/matterbridge.md` for instruction about using matterbridge in a plugin.
+- `.agents/plugin-frontend.md` for serving a plugin frontend SPA and exposing its custom REST API.
 - `.agents/chip-tests.md` for the CHIP conformance test harness and certification-test workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,4 @@ For task-specific guidance, read relevant files in [.agents](./.agents/):
 
 - `.agents/testing.md` for testing and validation expectations;
 - `.agents/matterbridge.md` for instruction about using matterbridge in a plugin.
+- `.agents/chip-tests.md` for the CHIP conformance test harness and certification-test workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 [![tested with Vitest](https://img.shields.io/badge/tested_with-Vitest-6E9F18.svg?logo=vitest&logoColor=white)](https://vitest.dev)
 [![styled with Oxc](https://img.shields.io/badge/styled_with-Oxc-9BE4E0.svg?logo=oxc&logoColor=white)](https://oxc.rs/docs/guide/usage/formatter.html)
 [![linted with Oxc](https://img.shields.io/badge/linted_with-Oxc-9BE4E0.svg?logo=oxc&logoColor=white)](https://oxc.rs/docs/guide/usage/linter.html)
-[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![TypeScript Native](https://img.shields.io/badge/TypeScript_Native-3178C6?logo=typescript&logoColor=white)](https://github.com/microsoft/typescript-go)
 [![ESM](https://img.shields.io/badge/ESM-Node.js-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![matterbridge.io](https://img.shields.io/badge/matterbridge.io-online-brightgreen)](https://matterbridge.io)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- eslint-disable markdown/no-missing-label-refs -->
-
 # <img src="https://matterbridge.io/assets/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge shelly plugin changelog
 
 [![npm version](https://img.shields.io/npm/v/matterbridge-shelly.svg)](https://www.npmjs.com/package/matterbridge-shelly)
@@ -43,8 +41,9 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 
 ### Changed
 
-- [package]: Bump `oxfmt` to v.0.61.0.
-- [package]: Bump `oxlint` to v.1.76.0.
+- [package]: Bump `ws` to v.8.21.2.
+- [package]: Bump `oxfmt` to v.0.62.0.
+- [package]: Bump `oxlint` to v.1.77.0.
 - [package]: Bump `oxlint-tsgolint` to v.7.0.2001.
 - [package]: Bump `@types/node` to v.26.1.2.
 - [package]: Update agents configs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,14 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 
 ### Breaking changes
 
-- [matterbridge]: Require matterbridge v.3.10.0 with matter v.1.6.0 and matter.js v.0.17.5.
+- [matterbridge]: Require matterbridge v.3.10.0 with matter v.1.6.0.
 
 ### Changed
 
-- [package]: Bump `oxfmt` to v.0.60.0.
-- [package]: Bump `oxlint` to v.1.75.0.
+- [package]: Bump `oxfmt` to v.0.61.0.
+- [package]: Bump `oxlint` to v.1.76.0.
 - [package]: Bump `oxlint-tsgolint` to v.7.0.2001.
+- [package]: Bump `@types/node` to v.26.1.2.
 - [package]: Update agents configs.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 
 - [matterbridge]: Require matterbridge v.3.10.0 with matter v.1.6.0 and matter.js v.0.17.5.
 
+### Changed
+
+- [package]: Bump `oxfmt` to v.0.60.0.
+- [package]: Bump `oxlint` to v.1.75.0.
+- [package]: Bump `oxlint-tsgolint` to v.7.0.2001.
+- [package]: Update agents configs.
+
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 
 ## [2.5.0] - 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ If you like this project and find it useful, please consider giving it a star on
 
 You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his invaluable contribution to this project.
 
+## [2.5.1] - Dev branch
+
+### Breaking changes
+
+- [matterbridge]: Require matterbridge v.3.10.0 with matter v.1.6.0 and matter.js v.0.17.5.
+
+<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
+
 ## [2.5.0] - 2026-07-17
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 
 - [matterbridge]: Require matterbridge v.3.10.0 with matter v.1.6.0.
 
+### Added
+
+- [chip] Add chip-test toolchain agents instruction and chip-test runner.
+- [frontend] Add plugin-frontend agents instructions.
+
 ### Changed
 
 - [package]: Bump `oxfmt` to v.0.61.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ If you like this project and find it useful, please consider giving it a star on
 
 You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his invaluable contribution to this project.
 
-## [2.5.1] - Dev branch
+## [2.5.1] - 2026-08-09
+
+### Firmware 2.0.0
+
+- [shelly]: The new firmware 2.0.0 is still under test. At the moment I see very frequent websocket disconnections.
 
 ### Breaking changes
 
@@ -38,15 +42,24 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 
 - [chip]: Add chip-test toolchain agents instruction and chip-test runner.
 - [frontend]: Add plugin-frontend agents instructions.
+- [blu]: Add `Shelly BLU Motion ZB` (`SBMO-103Z`).
+- [blu]: Verified `BLU Door Window ZB` with firmware 1.2.23.
+- [blu]: Verified `BLU H&T ZB` with firmware 1.2.12.
+
+### Fixed
+
+- [blu]: Fix BTHome device validation rejecting all `bthomedevice:*` components on gateway firmware 2.0.0+: the gateway now omits the `key` property from `config` (down to 4 properties: `id`, `name`, `addr`, `meta`) instead of sending it as `null`, even though the Shelly API docs still document `key` as part of the `BTHomeDevice` config schema. Relaxed the config validation minimum from 5 to 4 properties.
 
 ### Changed
 
-- [package]: Bump `ws` to v.8.21.2.
+- [package]: Bump `ws` to v.8.21.3.
 - [package]: Bump `oxfmt` to v.0.62.0.
 - [package]: Bump `oxlint` to v.1.77.0.
 - [package]: Bump `oxlint-tsgolint` to v.7.0.2001.
-- [package]: Bump `@types/node` to v.26.1.2.
+- [package]: Bump `@types/node` to v.26.2.0.
 - [package]: Update agents configs.
+- [package]: Update dependencies.
+- [package]: Upgrade package.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,6 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 - [blu]: Verified `BLU Door Window ZB` with firmware 1.2.23.
 - [blu]: Verified `BLU H&T ZB` with firmware 1.2.12.
 
-### Fixed
-
-- [blu]: Fix BTHome device validation rejecting all `bthomedevice:*` components on gateway firmware 2.0.0+: the gateway now omits the `key` property from `config` (down to 4 properties: `id`, `name`, `addr`, `meta`) instead of sending it as `null`, even though the Shelly API docs still document `key` as part of the `BTHomeDevice` config schema. Relaxed the config validation minimum from 5 to 4 properties.
-
 ### Changed
 
 - [package]: Bump `ws` to v.8.21.3.
@@ -60,6 +56,10 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 - [package]: Update agents configs.
 - [package]: Update dependencies.
 - [package]: Upgrade package.
+
+### Fixed
+
+- [blu]: Fix BTHome device validation rejecting all `bthomedevice:*` components on gateway firmware 2.0.0+: the gateway now omits the `key` property from `config` (down to 4 properties: `id`, `name`, `addr`, `meta`) instead of sending it as `null`, even though the Shelly API docs still document `key` as part of the `BTHomeDevice` config schema. Relaxed the config validation minimum from 5 to 4 properties.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ You can also sponsor Tamer here https://buymeacoffee.com/6sjde6vkzl for his inva
 
 ### Added
 
-- [chip] Add chip-test toolchain agents instruction and chip-test runner.
-- [frontend] Add plugin-frontend agents instructions.
+- [chip]: Add chip-test toolchain agents instruction and chip-test runner.
+- [frontend]: Add plugin-frontend agents instructions.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![tested with Vitest](https://img.shields.io/badge/tested_with-Vitest-6E9F18.svg?logo=vitest&logoColor=white)](https://vitest.dev)
 [![styled with Oxc](https://img.shields.io/badge/styled_with-Oxc-9BE4E0.svg?logo=oxc&logoColor=white)](https://oxc.rs/docs/guide/usage/formatter.html)
 [![linted with Oxc](https://img.shields.io/badge/linted_with-Oxc-9BE4E0.svg?logo=oxc&logoColor=white)](https://oxc.rs/docs/guide/usage/linter.html)
-[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![TypeScript Native](https://img.shields.io/badge/TypeScript_Native-3178C6?logo=typescript&logoColor=white)](https://github.com/microsoft/typescript-go)
 [![ESM](https://img.shields.io/badge/ESM-Node.js-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![matterbridge.io](https://img.shields.io/badge/matterbridge.io-online-brightgreen)](https://matterbridge.io)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -21,7 +21,7 @@ Concise rules the codebase and all agent suggestions should follow.
 
 - Functions: verb or verb phrase (`createDevice`, `updateState`).
 - Booleans: prefix with `is/has/can/should` (internal helpers); state flags in this project may keep existing names (`intervalOnOff`).
-- Private file‑local helpers start with `_` only if intentionally unused yet (silencing ESLint); otherwise export or remove.
+- Private file‑local helpers start with `_` only if intentionally unused yet (silencing the linter); otherwise export or remove.
 - Constants: `UPPER_SNAKE_CASE` only for process env or true constants; otherwise camelCase.
 
 ## 4. JSDoc Template

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
       },
       "devDependencies": {
         "@types/multicast-dns": "7.2.4",
-        "@types/node": "26.1.1",
+        "@types/node": "26.1.2",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "4.1.10",
-        "oxfmt": "0.60.0",
-        "oxlint": "1.75.0",
+        "oxfmt": "0.61.0",
+        "oxlint": "1.76.0",
         "oxlint-tsgolint": "7.0.2001",
         "typescript": "7.0.2",
         "vitest": "4.1.10"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -95,21 +95,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "2.0.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -163,28 +163,31 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -192,9 +195,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.60.0.tgz",
-      "integrity": "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.61.0.tgz",
+      "integrity": "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==",
       "cpu": [
         "arm"
       ],
@@ -209,9 +212,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.60.0.tgz",
-      "integrity": "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.61.0.tgz",
+      "integrity": "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==",
       "cpu": [
         "arm64"
       ],
@@ -226,9 +229,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.60.0.tgz",
-      "integrity": "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.61.0.tgz",
+      "integrity": "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==",
       "cpu": [
         "arm64"
       ],
@@ -243,9 +246,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.60.0.tgz",
-      "integrity": "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.61.0.tgz",
+      "integrity": "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==",
       "cpu": [
         "x64"
       ],
@@ -260,9 +263,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.60.0.tgz",
-      "integrity": "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.61.0.tgz",
+      "integrity": "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==",
       "cpu": [
         "x64"
       ],
@@ -277,9 +280,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.60.0.tgz",
-      "integrity": "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.61.0.tgz",
+      "integrity": "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==",
       "cpu": [
         "arm"
       ],
@@ -294,9 +297,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.60.0.tgz",
-      "integrity": "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.61.0.tgz",
+      "integrity": "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==",
       "cpu": [
         "arm"
       ],
@@ -311,9 +314,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.60.0.tgz",
-      "integrity": "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.61.0.tgz",
+      "integrity": "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==",
       "cpu": [
         "arm64"
       ],
@@ -331,9 +334,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.60.0.tgz",
-      "integrity": "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.61.0.tgz",
+      "integrity": "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==",
       "cpu": [
         "arm64"
       ],
@@ -351,9 +354,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.60.0.tgz",
-      "integrity": "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.61.0.tgz",
+      "integrity": "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==",
       "cpu": [
         "ppc64"
       ],
@@ -371,9 +374,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.60.0.tgz",
-      "integrity": "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.61.0.tgz",
+      "integrity": "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==",
       "cpu": [
         "riscv64"
       ],
@@ -391,9 +394,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.60.0.tgz",
-      "integrity": "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.61.0.tgz",
+      "integrity": "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==",
       "cpu": [
         "riscv64"
       ],
@@ -411,9 +414,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.60.0.tgz",
-      "integrity": "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.61.0.tgz",
+      "integrity": "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==",
       "cpu": [
         "s390x"
       ],
@@ -431,9 +434,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.60.0.tgz",
-      "integrity": "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.61.0.tgz",
+      "integrity": "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==",
       "cpu": [
         "x64"
       ],
@@ -451,9 +454,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.60.0.tgz",
-      "integrity": "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.61.0.tgz",
+      "integrity": "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==",
       "cpu": [
         "x64"
       ],
@@ -471,9 +474,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.60.0.tgz",
-      "integrity": "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.61.0.tgz",
+      "integrity": "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==",
       "cpu": [
         "arm64"
       ],
@@ -488,9 +491,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.60.0.tgz",
-      "integrity": "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.61.0.tgz",
+      "integrity": "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==",
       "cpu": [
         "arm64"
       ],
@@ -505,9 +508,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.60.0.tgz",
-      "integrity": "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.61.0.tgz",
+      "integrity": "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==",
       "cpu": [
         "ia32"
       ],
@@ -522,9 +525,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.60.0.tgz",
-      "integrity": "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.61.0.tgz",
+      "integrity": "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==",
       "cpu": [
         "x64"
       ],
@@ -623,9 +626,9 @@
       ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
-      "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
+      "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
       "cpu": [
         "arm"
       ],
@@ -640,9 +643,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
-      "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
+      "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
       "cpu": [
         "arm64"
       ],
@@ -657,9 +660,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
-      "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
+      "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
       "cpu": [
         "arm64"
       ],
@@ -674,9 +677,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
-      "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
+      "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
       "cpu": [
         "x64"
       ],
@@ -691,9 +694,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
-      "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
+      "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +711,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
-      "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
+      "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
       "cpu": [
         "arm"
       ],
@@ -725,9 +728,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
-      "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
+      "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
       "cpu": [
         "arm"
       ],
@@ -742,9 +745,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
-      "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
+      "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
       "cpu": [
         "arm64"
       ],
@@ -762,9 +765,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
-      "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
+      "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
       "cpu": [
         "arm64"
       ],
@@ -782,9 +785,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
-      "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
+      "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
       "cpu": [
         "ppc64"
       ],
@@ -802,9 +805,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
-      "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
+      "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
       "cpu": [
         "riscv64"
       ],
@@ -822,9 +825,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
-      "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
+      "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
       "cpu": [
         "riscv64"
       ],
@@ -842,9 +845,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
-      "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
+      "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
       "cpu": [
         "s390x"
       ],
@@ -862,9 +865,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
-      "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
+      "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
       "cpu": [
         "x64"
       ],
@@ -882,9 +885,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
-      "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
+      "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
       "cpu": [
         "x64"
       ],
@@ -902,9 +905,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
-      "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
+      "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
       "cpu": [
         "arm64"
       ],
@@ -919,9 +922,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
-      "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
+      "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
       "cpu": [
         "arm64"
       ],
@@ -936,9 +939,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
-      "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
+      "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
       "cpu": [
         "ia32"
       ],
@@ -953,9 +956,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
-      "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
+      "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
       "cpu": [
         "x64"
       ],
@@ -970,9 +973,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
       "cpu": [
         "arm64"
       ],
@@ -987,9 +990,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
       "cpu": [
         "arm64"
       ],
@@ -1004,9 +1007,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
       "cpu": [
         "x64"
       ],
@@ -1021,9 +1024,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
       "cpu": [
         "x64"
       ],
@@ -1038,9 +1041,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
       "cpu": [
         "arm"
       ],
@@ -1055,9 +1058,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
       "cpu": [
         "arm64"
       ],
@@ -1075,9 +1078,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
       ],
@@ -1095,9 +1098,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1115,9 +1118,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
       ],
@@ -1135,9 +1138,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
       "cpu": [
         "x64"
       ],
@@ -1155,9 +1158,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
       ],
@@ -1175,9 +1178,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1192,28 +1195,25 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
       "cpu": [
         "arm64"
       ],
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
       "cpu": [
         "x64"
       ],
@@ -1316,9 +1316,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2473,14 +2473,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
       }
     },
@@ -2623,9 +2623,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.60.0.tgz",
-      "integrity": "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.61.0.tgz",
+      "integrity": "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2641,25 +2641,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.60.0",
-        "@oxfmt/binding-android-arm64": "0.60.0",
-        "@oxfmt/binding-darwin-arm64": "0.60.0",
-        "@oxfmt/binding-darwin-x64": "0.60.0",
-        "@oxfmt/binding-freebsd-x64": "0.60.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.60.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.60.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.60.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.60.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-x64-musl": "0.60.0",
-        "@oxfmt/binding-openharmony-arm64": "0.60.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.60.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.60.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.60.0"
+        "@oxfmt/binding-android-arm-eabi": "0.61.0",
+        "@oxfmt/binding-android-arm64": "0.61.0",
+        "@oxfmt/binding-darwin-arm64": "0.61.0",
+        "@oxfmt/binding-darwin-x64": "0.61.0",
+        "@oxfmt/binding-freebsd-x64": "0.61.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.61.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.61.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.61.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.61.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-x64-musl": "0.61.0",
+        "@oxfmt/binding-openharmony-arm64": "0.61.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.61.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.61.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.61.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -2675,9 +2675,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
-      "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
+      "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2690,25 +2690,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.75.0",
-        "@oxlint/binding-android-arm64": "1.75.0",
-        "@oxlint/binding-darwin-arm64": "1.75.0",
-        "@oxlint/binding-darwin-x64": "1.75.0",
-        "@oxlint/binding-freebsd-x64": "1.75.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.75.0",
-        "@oxlint/binding-linux-arm64-musl": "1.75.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.75.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.75.0",
-        "@oxlint/binding-linux-x64-gnu": "1.75.0",
-        "@oxlint/binding-linux-x64-musl": "1.75.0",
-        "@oxlint/binding-openharmony-arm64": "1.75.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.75.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.75.0",
-        "@oxlint/binding-win32-x64-msvc": "1.75.0"
+        "@oxlint/binding-android-arm-eabi": "1.76.0",
+        "@oxlint/binding-android-arm64": "1.76.0",
+        "@oxlint/binding-darwin-arm64": "1.76.0",
+        "@oxlint/binding-darwin-x64": "1.76.0",
+        "@oxlint/binding-freebsd-x64": "1.76.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.76.0",
+        "@oxlint/binding-linux-arm64-musl": "1.76.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.76.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-musl": "1.76.0",
+        "@oxlint/binding-openharmony-arm64": "1.76.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.76.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.76.0",
+        "@oxlint/binding-win32-x64-msvc": "1.76.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -2769,9 +2769,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2823,13 +2823,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2839,21 +2839,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
     "node_modules/safe-buffer": {
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3052,16 +3052,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3078,7 +3078,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,15 @@
         "multicast-dns": "7.2.5",
         "node-ansi-logger": "3.3.0",
         "node-persist-manager": "2.1.0",
-        "ws": "8.21.1"
+        "ws": "8.21.2"
       },
       "devDependencies": {
         "@types/multicast-dns": "7.2.4",
         "@types/node": "26.1.2",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "4.1.10",
-        "oxfmt": "0.61.0",
-        "oxlint": "1.76.0",
+        "oxfmt": "0.62.0",
+        "oxlint": "1.77.0",
         "oxlint-tsgolint": "7.0.2001",
         "typescript": "7.0.2",
         "vitest": "4.1.10"
@@ -94,40 +94,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -162,32 +128,10 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
-      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
-      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -195,9 +139,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.61.0.tgz",
-      "integrity": "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.62.0.tgz",
+      "integrity": "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==",
       "cpu": [
         "arm"
       ],
@@ -212,9 +156,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.61.0.tgz",
-      "integrity": "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.62.0.tgz",
+      "integrity": "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==",
       "cpu": [
         "arm64"
       ],
@@ -229,9 +173,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.61.0.tgz",
-      "integrity": "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.62.0.tgz",
+      "integrity": "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==",
       "cpu": [
         "arm64"
       ],
@@ -246,9 +190,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.61.0.tgz",
-      "integrity": "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.62.0.tgz",
+      "integrity": "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==",
       "cpu": [
         "x64"
       ],
@@ -263,9 +207,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.61.0.tgz",
-      "integrity": "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.62.0.tgz",
+      "integrity": "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==",
       "cpu": [
         "x64"
       ],
@@ -280,9 +224,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.61.0.tgz",
-      "integrity": "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.62.0.tgz",
+      "integrity": "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==",
       "cpu": [
         "arm"
       ],
@@ -297,9 +241,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.61.0.tgz",
-      "integrity": "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.62.0.tgz",
+      "integrity": "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==",
       "cpu": [
         "arm"
       ],
@@ -314,9 +258,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.61.0.tgz",
-      "integrity": "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.62.0.tgz",
+      "integrity": "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==",
       "cpu": [
         "arm64"
       ],
@@ -334,9 +278,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.61.0.tgz",
-      "integrity": "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.62.0.tgz",
+      "integrity": "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==",
       "cpu": [
         "arm64"
       ],
@@ -354,9 +298,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.61.0.tgz",
-      "integrity": "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.62.0.tgz",
+      "integrity": "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==",
       "cpu": [
         "ppc64"
       ],
@@ -374,9 +318,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.61.0.tgz",
-      "integrity": "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.62.0.tgz",
+      "integrity": "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==",
       "cpu": [
         "riscv64"
       ],
@@ -394,9 +338,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.61.0.tgz",
-      "integrity": "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.62.0.tgz",
+      "integrity": "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==",
       "cpu": [
         "riscv64"
       ],
@@ -414,9 +358,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.61.0.tgz",
-      "integrity": "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.62.0.tgz",
+      "integrity": "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==",
       "cpu": [
         "s390x"
       ],
@@ -434,9 +378,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.61.0.tgz",
-      "integrity": "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.62.0.tgz",
+      "integrity": "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==",
       "cpu": [
         "x64"
       ],
@@ -454,9 +398,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.61.0.tgz",
-      "integrity": "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.62.0.tgz",
+      "integrity": "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==",
       "cpu": [
         "x64"
       ],
@@ -474,9 +418,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.61.0.tgz",
-      "integrity": "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.62.0.tgz",
+      "integrity": "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==",
       "cpu": [
         "arm64"
       ],
@@ -491,9 +435,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.61.0.tgz",
-      "integrity": "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.62.0.tgz",
+      "integrity": "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==",
       "cpu": [
         "arm64"
       ],
@@ -508,9 +452,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.61.0.tgz",
-      "integrity": "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.62.0.tgz",
+      "integrity": "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==",
       "cpu": [
         "ia32"
       ],
@@ -525,9 +469,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.61.0.tgz",
-      "integrity": "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.62.0.tgz",
+      "integrity": "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==",
       "cpu": [
         "x64"
       ],
@@ -626,9 +570,9 @@
       ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
-      "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
+      "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
       "cpu": [
         "arm"
       ],
@@ -643,9 +587,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
-      "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
       "cpu": [
         "arm64"
       ],
@@ -660,9 +604,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
-      "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
       "cpu": [
         "arm64"
       ],
@@ -677,9 +621,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
-      "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
       "cpu": [
         "x64"
       ],
@@ -694,9 +638,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
-      "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
+      "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
       "cpu": [
         "x64"
       ],
@@ -711,9 +655,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
-      "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
+      "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
       "cpu": [
         "arm"
       ],
@@ -728,9 +672,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
-      "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
+      "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
       "cpu": [
         "arm"
       ],
@@ -745,9 +689,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
-      "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
+      "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
       "cpu": [
         "arm64"
       ],
@@ -765,9 +709,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
-      "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
+      "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
       "cpu": [
         "arm64"
       ],
@@ -785,9 +729,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
-      "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
+      "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
       "cpu": [
         "ppc64"
       ],
@@ -805,9 +749,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
-      "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
+      "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
       "cpu": [
         "riscv64"
       ],
@@ -825,9 +769,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
-      "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
+      "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
       "cpu": [
         "riscv64"
       ],
@@ -845,9 +789,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
-      "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
+      "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
       "cpu": [
         "s390x"
       ],
@@ -865,9 +809,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
-      "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
+      "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
       "cpu": [
         "x64"
       ],
@@ -885,9 +829,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
-      "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
+      "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
       "cpu": [
         "x64"
       ],
@@ -905,9 +849,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
-      "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
+      "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
       "cpu": [
         "arm64"
       ],
@@ -922,9 +866,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
-      "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
+      "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
       "cpu": [
         "arm64"
       ],
@@ -939,9 +883,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
-      "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
+      "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
       "cpu": [
         "ia32"
       ],
@@ -956,9 +900,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
-      "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
+      "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
       "cpu": [
         "x64"
       ],
@@ -973,9 +917,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
-      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
@@ -990,9 +934,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
-      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
@@ -1007,9 +951,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
-      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
@@ -1024,9 +968,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
-      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
@@ -1041,9 +985,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
-      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
@@ -1058,9 +1002,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
-      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
@@ -1078,9 +1022,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
-      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1098,9 +1042,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
-      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
@@ -1118,9 +1062,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
-      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
@@ -1138,9 +1082,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
-      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
@@ -1158,9 +1102,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
-      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
@@ -1178,9 +1122,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
-      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
@@ -1194,26 +1138,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
-      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "2.0.0-alpha.3",
-        "@emnapi/runtime": "2.0.0-alpha.3",
-        "@napi-rs/wasm-runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
-      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
@@ -1228,9 +1156,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
-      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
@@ -1257,17 +1185,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2520,9 +2437,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -2623,9 +2540,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.61.0.tgz",
-      "integrity": "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.62.0.tgz",
+      "integrity": "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2641,25 +2558,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.61.0",
-        "@oxfmt/binding-android-arm64": "0.61.0",
-        "@oxfmt/binding-darwin-arm64": "0.61.0",
-        "@oxfmt/binding-darwin-x64": "0.61.0",
-        "@oxfmt/binding-freebsd-x64": "0.61.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.61.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.61.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.61.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.61.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.61.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.61.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.61.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.61.0",
-        "@oxfmt/binding-linux-x64-musl": "0.61.0",
-        "@oxfmt/binding-openharmony-arm64": "0.61.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.61.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.61.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.61.0"
+        "@oxfmt/binding-android-arm-eabi": "0.62.0",
+        "@oxfmt/binding-android-arm64": "0.62.0",
+        "@oxfmt/binding-darwin-arm64": "0.62.0",
+        "@oxfmt/binding-darwin-x64": "0.62.0",
+        "@oxfmt/binding-freebsd-x64": "0.62.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.62.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.62.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.62.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.62.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.62.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.62.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.62.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.62.0",
+        "@oxfmt/binding-linux-x64-musl": "0.62.0",
+        "@oxfmt/binding-openharmony-arm64": "0.62.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.62.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.62.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.62.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -2675,9 +2592,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
-      "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
+      "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2690,25 +2607,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.76.0",
-        "@oxlint/binding-android-arm64": "1.76.0",
-        "@oxlint/binding-darwin-arm64": "1.76.0",
-        "@oxlint/binding-darwin-x64": "1.76.0",
-        "@oxlint/binding-freebsd-x64": "1.76.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.76.0",
-        "@oxlint/binding-linux-arm64-musl": "1.76.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.76.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.76.0",
-        "@oxlint/binding-linux-x64-gnu": "1.76.0",
-        "@oxlint/binding-linux-x64-musl": "1.76.0",
-        "@oxlint/binding-openharmony-arm64": "1.76.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.76.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.76.0",
-        "@oxlint/binding-win32-x64-msvc": "1.76.0"
+        "@oxlint/binding-android-arm-eabi": "1.77.0",
+        "@oxlint/binding-android-arm64": "1.77.0",
+        "@oxlint/binding-darwin-arm64": "1.77.0",
+        "@oxlint/binding-darwin-x64": "1.77.0",
+        "@oxlint/binding-freebsd-x64": "1.77.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.77.0",
+        "@oxlint/binding-linux-arm64-musl": "1.77.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.77.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-musl": "1.77.0",
+        "@oxlint/binding-openharmony-arm64": "1.77.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.77.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.77.0",
+        "@oxlint/binding-win32-x64-msvc": "1.77.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -2769,9 +2686,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2789,7 +2706,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2823,13 +2740,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
-      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.142.0",
+        "@oxc-project/types": "=0.143.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2839,21 +2756,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.1",
-        "@rolldown/binding-darwin-arm64": "1.2.1",
-        "@rolldown/binding-darwin-x64": "1.2.1",
-        "@rolldown/binding-freebsd-x64": "1.2.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
-        "@rolldown/binding-linux-arm64-musl": "1.2.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
-        "@rolldown/binding-linux-x64-gnu": "1.2.1",
-        "@rolldown/binding-linux-x64-musl": "1.2.1",
-        "@rolldown/binding-openharmony-arm64": "1.2.1",
-        "@rolldown/binding-wasm32-wasi": "1.2.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
-        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/safe-buffer": {
@@ -3001,14 +2917,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/typescript": {
       "version": "7.0.2",
@@ -3237,9 +3145,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
         "@types/node": "26.1.1",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "4.1.10",
-        "oxfmt": "0.59.0",
-        "oxlint": "1.74.0",
-        "oxlint-tsgolint": "0.25.0",
+        "oxfmt": "0.60.0",
+        "oxlint": "1.75.0",
+        "oxlint-tsgolint": "7.0.2001",
         "typescript": "7.0.2",
         "vitest": "4.1.10"
       },
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.59.0.tgz",
-      "integrity": "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.60.0.tgz",
+      "integrity": "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==",
       "cpu": [
         "arm"
       ],
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.59.0.tgz",
-      "integrity": "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.60.0.tgz",
+      "integrity": "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw==",
       "cpu": [
         "arm64"
       ],
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.59.0.tgz",
-      "integrity": "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.60.0.tgz",
+      "integrity": "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw==",
       "cpu": [
         "arm64"
       ],
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.59.0.tgz",
-      "integrity": "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.60.0.tgz",
+      "integrity": "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q==",
       "cpu": [
         "x64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.59.0.tgz",
-      "integrity": "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.60.0.tgz",
+      "integrity": "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA==",
       "cpu": [
         "x64"
       ],
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.59.0.tgz",
-      "integrity": "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.60.0.tgz",
+      "integrity": "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g==",
       "cpu": [
         "arm"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.59.0.tgz",
-      "integrity": "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.60.0.tgz",
+      "integrity": "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA==",
       "cpu": [
         "arm"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.59.0.tgz",
-      "integrity": "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.60.0.tgz",
+      "integrity": "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw==",
       "cpu": [
         "arm64"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.59.0.tgz",
-      "integrity": "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.60.0.tgz",
+      "integrity": "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q==",
       "cpu": [
         "arm64"
       ],
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.59.0.tgz",
-      "integrity": "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.60.0.tgz",
+      "integrity": "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A==",
       "cpu": [
         "ppc64"
       ],
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.59.0.tgz",
-      "integrity": "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.60.0.tgz",
+      "integrity": "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA==",
       "cpu": [
         "riscv64"
       ],
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.59.0.tgz",
-      "integrity": "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.60.0.tgz",
+      "integrity": "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg==",
       "cpu": [
         "riscv64"
       ],
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.59.0.tgz",
-      "integrity": "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.60.0.tgz",
+      "integrity": "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw==",
       "cpu": [
         "s390x"
       ],
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.59.0.tgz",
-      "integrity": "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.60.0.tgz",
+      "integrity": "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q==",
       "cpu": [
         "x64"
       ],
@@ -451,9 +451,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.59.0.tgz",
-      "integrity": "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.60.0.tgz",
+      "integrity": "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg==",
       "cpu": [
         "x64"
       ],
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.59.0.tgz",
-      "integrity": "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.60.0.tgz",
+      "integrity": "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg==",
       "cpu": [
         "arm64"
       ],
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.59.0.tgz",
-      "integrity": "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.60.0.tgz",
+      "integrity": "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ==",
       "cpu": [
         "arm64"
       ],
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.59.0.tgz",
-      "integrity": "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.60.0.tgz",
+      "integrity": "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q==",
       "cpu": [
         "ia32"
       ],
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.59.0.tgz",
-      "integrity": "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.60.0.tgz",
+      "integrity": "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==",
       "cpu": [
         "x64"
       ],
@@ -539,9 +539,9 @@
       }
     },
     "node_modules/@oxlint-tsgolint/darwin-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
-      "integrity": "sha512-87opKlwFP8qS9WHAeETV+kA0fC9Oyj4sg7OxWdI4xQY0WC7zlN6BgG66uE5mvtN5mahkt/gL0i/AVEnX6POq2Q==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-7.0.2001.tgz",
+      "integrity": "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==",
       "cpu": [
         "arm64"
       ],
@@ -553,9 +553,9 @@
       ]
     },
     "node_modules/@oxlint-tsgolint/darwin-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.25.0.tgz",
-      "integrity": "sha512-HJmuZexsrhqp4WmETn+Soq7Ogt5F0jirv+cYRSniIPe+d/x5beQzLX69xOLhQRE+8FLGETe7FahWMVP8x0dW4g==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-7.0.2001.tgz",
+      "integrity": "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==",
       "cpu": [
         "x64"
       ],
@@ -567,9 +567,9 @@
       ]
     },
     "node_modules/@oxlint-tsgolint/linux-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.25.0.tgz",
-      "integrity": "sha512-aNyYsPREvCJi3qjfBA0sQB7DhT3y/W5Ac2JI2D8IJynoTOAhVZj401Si6901oDajlBWyqJqqojudn0VgHB6+7A==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-7.0.2001.tgz",
+      "integrity": "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==",
       "cpu": [
         "arm64"
       ],
@@ -581,9 +581,9 @@
       ]
     },
     "node_modules/@oxlint-tsgolint/linux-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.25.0.tgz",
-      "integrity": "sha512-+60+VjK9Mch3uA5WlTdNHuAm5+WA7wPPjuWdPWlU0F6JJpYpGZXUpO1RPKuFEWsBpNbLcLeJ0LbCJ1doWu58NA==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-7.0.2001.tgz",
+      "integrity": "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==",
       "cpu": [
         "x64"
       ],
@@ -595,9 +595,9 @@
       ]
     },
     "node_modules/@oxlint-tsgolint/win32-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.25.0.tgz",
-      "integrity": "sha512-r53TO+eHp/t53nnUkQJfrYYXODPAxmtf3RUFQG5XsE2hD21IunliOaAdZXP2UwzCx+r/fbNaEelqTaAHcDr57w==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-7.0.2001.tgz",
+      "integrity": "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==",
       "cpu": [
         "arm64"
       ],
@@ -609,9 +609,9 @@
       ]
     },
     "node_modules/@oxlint-tsgolint/win32-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.25.0.tgz",
-      "integrity": "sha512-vqe66B+gL9HarhyHemdlfC2VWT7eoA+o/ufZ7zT6AGHv64boyDZIJS3U+rpZo+ey4O7wZtiS/vYR2fWqDoFeBw==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-7.0.2001.tgz",
+      "integrity": "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==",
       "cpu": [
         "x64"
       ],
@@ -623,9 +623,9 @@
       ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.74.0.tgz",
-      "integrity": "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
+      "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
       "cpu": [
         "arm"
       ],
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.74.0.tgz",
-      "integrity": "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
+      "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
       "cpu": [
         "arm64"
       ],
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.74.0.tgz",
-      "integrity": "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
+      "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
       "cpu": [
         "arm64"
       ],
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.74.0.tgz",
-      "integrity": "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
+      "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
       "cpu": [
         "x64"
       ],
@@ -691,9 +691,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.74.0.tgz",
-      "integrity": "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
+      "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +708,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.74.0.tgz",
-      "integrity": "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
+      "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
       "cpu": [
         "arm"
       ],
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.74.0.tgz",
-      "integrity": "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
+      "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
       "cpu": [
         "arm"
       ],
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.74.0.tgz",
-      "integrity": "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
+      "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
       "cpu": [
         "arm64"
       ],
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.74.0.tgz",
-      "integrity": "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
+      "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
       "cpu": [
         "arm64"
       ],
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.74.0.tgz",
-      "integrity": "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
+      "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
       "cpu": [
         "ppc64"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.74.0.tgz",
-      "integrity": "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
+      "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
       "cpu": [
         "riscv64"
       ],
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.74.0.tgz",
-      "integrity": "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
+      "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
       "cpu": [
         "riscv64"
       ],
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.74.0.tgz",
-      "integrity": "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
+      "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
       "cpu": [
         "s390x"
       ],
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.74.0.tgz",
-      "integrity": "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
+      "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
       "cpu": [
         "x64"
       ],
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.74.0.tgz",
-      "integrity": "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
+      "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
       "cpu": [
         "x64"
       ],
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.74.0.tgz",
-      "integrity": "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
+      "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
       "cpu": [
         "arm64"
       ],
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.74.0.tgz",
-      "integrity": "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
+      "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
       "cpu": [
         "arm64"
       ],
@@ -936,9 +936,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.74.0.tgz",
-      "integrity": "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
+      "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
       "cpu": [
         "ia32"
       ],
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.74.0.tgz",
-      "integrity": "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
+      "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
       "cpu": [
         "x64"
       ],
@@ -2181,9 +2181,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -2197,23 +2197,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -2253,9 +2253,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -2274,9 +2274,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -2340,9 +2340,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -2364,9 +2364,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -2388,9 +2388,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -2412,9 +2412,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -2433,9 +2433,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -2623,9 +2623,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.59.0.tgz",
-      "integrity": "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.60.0.tgz",
+      "integrity": "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2641,25 +2641,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.59.0",
-        "@oxfmt/binding-android-arm64": "0.59.0",
-        "@oxfmt/binding-darwin-arm64": "0.59.0",
-        "@oxfmt/binding-darwin-x64": "0.59.0",
-        "@oxfmt/binding-freebsd-x64": "0.59.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.59.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.59.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.59.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.59.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.59.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.59.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.59.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.59.0",
-        "@oxfmt/binding-linux-x64-musl": "0.59.0",
-        "@oxfmt/binding-openharmony-arm64": "0.59.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.59.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.59.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.59.0"
+        "@oxfmt/binding-android-arm-eabi": "0.60.0",
+        "@oxfmt/binding-android-arm64": "0.60.0",
+        "@oxfmt/binding-darwin-arm64": "0.60.0",
+        "@oxfmt/binding-darwin-x64": "0.60.0",
+        "@oxfmt/binding-freebsd-x64": "0.60.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.60.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.60.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.60.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.60.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.60.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.60.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.60.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.60.0",
+        "@oxfmt/binding-linux-x64-musl": "0.60.0",
+        "@oxfmt/binding-openharmony-arm64": "0.60.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.60.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.60.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.60.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -2675,9 +2675,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.74.0.tgz",
-      "integrity": "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
+      "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2690,28 +2690,28 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.74.0",
-        "@oxlint/binding-android-arm64": "1.74.0",
-        "@oxlint/binding-darwin-arm64": "1.74.0",
-        "@oxlint/binding-darwin-x64": "1.74.0",
-        "@oxlint/binding-freebsd-x64": "1.74.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.74.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.74.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.74.0",
-        "@oxlint/binding-linux-arm64-musl": "1.74.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.74.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.74.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.74.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.74.0",
-        "@oxlint/binding-linux-x64-gnu": "1.74.0",
-        "@oxlint/binding-linux-x64-musl": "1.74.0",
-        "@oxlint/binding-openharmony-arm64": "1.74.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.74.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.74.0",
-        "@oxlint/binding-win32-x64-msvc": "1.74.0"
+        "@oxlint/binding-android-arm-eabi": "1.75.0",
+        "@oxlint/binding-android-arm64": "1.75.0",
+        "@oxlint/binding-darwin-arm64": "1.75.0",
+        "@oxlint/binding-darwin-x64": "1.75.0",
+        "@oxlint/binding-freebsd-x64": "1.75.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.75.0",
+        "@oxlint/binding-linux-arm64-musl": "1.75.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.75.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.75.0",
+        "@oxlint/binding-linux-x64-gnu": "1.75.0",
+        "@oxlint/binding-linux-x64-musl": "1.75.0",
+        "@oxlint/binding-openharmony-arm64": "1.75.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.75.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.75.0",
+        "@oxlint/binding-win32-x64-msvc": "1.75.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.24.0",
+        "oxlint-tsgolint": ">=7.0.2001",
         "vite-plus": "*"
       },
       "peerDependenciesMeta": {
@@ -2724,21 +2724,21 @@
       }
     },
     "node_modules/oxlint-tsgolint": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.25.0.tgz",
-      "integrity": "sha512-7DBpqyLZCfyoXiivyfzt9Xmju/K1RcN+Y1W7buEwrgRCWWF11v9alypPqWGZBmh2erDkKL/kVyhKUH2Px+t13A==",
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-7.0.2001.tgz",
+      "integrity": "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "tsgolint": "bin/tsgolint.js"
       },
       "optionalDependencies": {
-        "@oxlint-tsgolint/darwin-arm64": "0.25.0",
-        "@oxlint-tsgolint/darwin-x64": "0.25.0",
-        "@oxlint-tsgolint/linux-arm64": "0.25.0",
-        "@oxlint-tsgolint/linux-x64": "0.25.0",
-        "@oxlint-tsgolint/win32-arm64": "0.25.0",
-        "@oxlint-tsgolint/win32-x64": "0.25.0"
+        "@oxlint-tsgolint/darwin-arm64": "7.0.2001",
+        "@oxlint-tsgolint/darwin-x64": "7.0.2001",
+        "@oxlint-tsgolint/linux-arm64": "7.0.2001",
+        "@oxlint-tsgolint/linux-x64": "7.0.2001",
+        "@oxlint-tsgolint/win32-arm64": "7.0.2001",
+        "@oxlint-tsgolint/win32-x64": "7.0.2001"
       }
     },
     "node_modules/pathe": {
@@ -2769,9 +2769,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2789,7 +2789,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-shelly",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "coap": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "multicast-dns": "7.2.5",
         "node-ansi-logger": "3.3.0",
         "node-persist-manager": "2.1.0",
-        "ws": "8.21.2"
+        "ws": "8.21.3"
       },
       "devDependencies": {
         "@types/multicast-dns": "7.2.4",
-        "@types/node": "26.1.2",
+        "@types/node": "26.2.0",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "4.1.10",
         "oxfmt": "0.62.0",
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2437,9 +2437,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2960,16 +2960,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
-      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.23",
-        "rolldown": "~1.2.0",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3145,9 +3145,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,9 +2956,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -125,9 +125,9 @@
     "@types/node": "26.1.1",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.10",
-    "oxfmt": "0.59.0",
-    "oxlint": "1.74.0",
-    "oxlint-tsgolint": "0.25.0",
+    "oxfmt": "0.60.0",
+    "oxlint": "1.75.0",
+    "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",
     "vitest": "4.1.10"
   }

--- a/package.json
+++ b/package.json
@@ -118,11 +118,11 @@
     "multicast-dns": "7.2.5",
     "node-ansi-logger": "3.3.0",
     "node-persist-manager": "2.1.0",
-    "ws": "8.21.2"
+    "ws": "8.21.3"
   },
   "devDependencies": {
     "@types/multicast-dns": "7.2.4",
-    "@types/node": "26.1.2",
+    "@types/node": "26.2.0",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.10",
     "oxfmt": "0.62.0",

--- a/package.json
+++ b/package.json
@@ -118,15 +118,15 @@
     "multicast-dns": "7.2.5",
     "node-ansi-logger": "3.3.0",
     "node-persist-manager": "2.1.0",
-    "ws": "8.21.1"
+    "ws": "8.21.2"
   },
   "devDependencies": {
     "@types/multicast-dns": "7.2.4",
     "@types/node": "26.1.2",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.10",
-    "oxfmt": "0.61.0",
-    "oxlint": "1.76.0",
+    "oxfmt": "0.62.0",
+    "oxlint": "1.77.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",
     "vitest": "4.1.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-shelly",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Matterbridge shelly plugin",
   "author": "https://github.com/Luligu",
   "homepage": "https://www.npmjs.com/package/matterbridge-shelly",

--- a/package.json
+++ b/package.json
@@ -122,11 +122,11 @@
   },
   "devDependencies": {
     "@types/multicast-dns": "7.2.4",
-    "@types/node": "26.1.1",
+    "@types/node": "26.1.2",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.10",
-    "oxfmt": "0.60.0",
-    "oxlint": "1.75.0",
+    "oxfmt": "0.61.0",
+    "oxlint": "1.76.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",
     "vitest": "4.1.10"

--- a/scripts/deep-clean.mjs
+++ b/scripts/deep-clean.mjs
@@ -1,13 +1,14 @@
 /**
  * deep-clean.mjs
- * Version: 1.1.0
+ * Version: 1.1.1
  *
  * Dependency-free replacement for:
- *   npx shx rm -rf *.tsbuildinfo dist build coverage jest temp package-lock.json npm-shrinkwrap.json \
+ *   npx shx rm -rf *.tsbuildinfo dist build coverage jest temp bun.lock package-lock.json npm-shrinkwrap.json \
  *     .cache/* .cache/.[!.]* .cache/..?* node_modules/* node_modules/.[!.]* node_modules/..?*
  *
  * Fully removes the *.tsbuildinfo files, build/test output directories and lock files,
- * then empties the contents of .cache and node_modules while keeping those directories.
+ * At the root, it empties the contents of .cache and node_modules while keeping those
+ * directories. In workspaces, it removes the entire .cache and node_modules directories.
  *
  * With `--workspaces`, it first cleans the root directory and then cleans every
  * workspace listed in the root package.json `workspaces` array. Simple workspace
@@ -41,7 +42,7 @@ const rm = (dir, target) => {
   }
 };
 
-const clean = (dir) => {
+const clean = (dir, workspace) => {
   // Fully removed entries. The `.cache/*`, `node_modules/*` style globs keep the parent
   // directory and only delete its contents, so those are handled separately below.
   let targets;
@@ -50,9 +51,15 @@ const clean = (dir) => {
   } catch {
     return; // Directory does not exist, nothing to clean.
   }
-  targets.push('dist', 'build', 'coverage', 'jest', 'temp', 'package-lock.json', 'npm-shrinkwrap.json');
+  targets.push('dist', 'build', 'coverage', 'jest', 'temp', 'bun.lock', 'package-lock.json', 'npm-shrinkwrap.json');
   for (const target of targets) {
     rm(dir, target);
+  }
+
+  if (workspace) {
+    rm(dir, '.cache');
+    rm(dir, 'node_modules');
+    return;
   }
 
   // Empty the contents (including dotfiles) of these directories but keep the directory itself.
@@ -99,10 +106,10 @@ const getWorkspaceDirs = () => {
   return dirs;
 };
 
-clean(root);
+clean(root, false);
 
 if (process.argv.includes('--workspaces')) {
   for (const workspaceDir of getWorkspaceDirs()) {
-    clean(workspaceDir);
+    clean(workspaceDir, true);
   }
 }

--- a/scripts/git-sync-dev.mjs
+++ b/scripts/git-sync-dev.mjs
@@ -1,0 +1,66 @@
+/**
+ * git-sync-dev.mjs
+ * Version: 1.0.0
+ *
+ * Syncs the dev branch with origin/main via merge or rebase, after creating
+ * a timestamped local backup branch and fetching from origin.
+ *
+ * Usage:
+ *   node scripts/git-sync-dev.mjs merge
+ *   node scripts/git-sync-dev.mjs rebase
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Executes Git with inherited standard input/output.
+ *
+ * @param {string[]} args Git command arguments.
+ * @returns {void}
+ */
+function git(args) {
+  execFileSync('git', args, {
+    stdio: 'inherit',
+    shell: false,
+  });
+}
+
+/**
+ * Returns a filesystem- and Git-ref-safe local timestamp.
+ *
+ * @returns {string} Timestamp formatted as YYYYMMDD-HHmmss.
+ */
+function createTimestamp() {
+  const now = new Date();
+
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+
+  return `${year}${month}${day}-${hours}${minutes}${seconds}`;
+}
+
+const operation = process.argv[2];
+
+if (operation !== 'merge' && operation !== 'rebase') {
+  throw new Error('Usage: node scripts/git-sync-dev.mjs <merge|rebase>');
+}
+
+const backupBranch = `dev-backup-${createTimestamp()}`;
+
+git(['fetch', 'origin']);
+git(['switch', 'dev']);
+git(['branch', backupBranch]);
+
+console.log(`Created backup branch: ${backupBranch}`);
+
+if (operation === 'merge') {
+  git(['merge', 'origin/main']);
+  git(['push', 'origin', 'dev']);
+} else {
+  git(['rebase', 'origin/main']);
+  git(['push', '--force-with-lease', 'origin', 'dev']);
+}

--- a/scripts/run-chip-tests.mjs
+++ b/scripts/run-chip-tests.mjs
@@ -1,0 +1,473 @@
+/**
+ * run-chip-tests.mjs
+ * Version: 1.5.0
+ *
+ * Manage the `luligu/matterbridge:chip-test` docker container for the plugin in the current working
+ * directory and run the Matter CHIP test suite defined in chipTests.json, logging full results to
+ * chipTests.log and just the pass/fail summary to chipTestsSummary.log. Not specific to any one plugin:
+ * drop a chipTests.json into any plugin repo and this script picks up its name, config, and tests from it.
+ *
+ * chipTests.json shape:
+ *   "config"              (required) The plugin's config.json content, written into the container as
+ *                          /root/.matterbridge/<config.name>.config.json before the container is restarted
+ *                          in --start. "config.name" is also used as the plugin (npm package) name for the
+ *                          container's volume mount and `matterbridge --add`.
+ *   "resetClusterGlobs"   (optional) Filename globs (matched against files under this plugin's node
+ *                          storage directory for the bridged endpoints) cleared by a "resetBefore": true or
+ *                          "resetAfter": true test entry — see below. Defaults to an empty array; a test
+ *                          entry using either flag with nothing configured here fails loudly instead of
+ *                          silently doing nothing. Only needs entries for cluster state that's actually
+ *                          persisted to disk (e.g. CameraAvStreamManagement's allocated streams, Chime
+ *                          state) — the container restart that "resetBefore"/"resetAfter" also performs
+ *                          already clears any cluster state kept purely in memory (e.g. WebRTC Transport
+ *                          Provider's CurrentSessions), with no glob needed for that.
+ *   "yamlTests"            (optional) The list of YAML certification tests (run through chip-tool's
+ *                          websocket test runner, scripts/tests/chipyaml/chiptool.py) to run — see below.
+ *                          chip-tool's own persistent storage inside the image already holds a fabric paired
+ *                          with the matterbridge instance, so each invocation just spawns a short-lived
+ *                          `chip-tool interactive server`, runs the one test, and tears it down again — no
+ *                          separate commissioning step needed. Defaults to an empty array.
+ *   "phytonTests"          (optional) The list of Python (src/python_testing/*.py) tests to run — see
+ *                          below. Defaults to an empty array.
+ * Each yamlTests/phytonTests entry may set an "input" string, piped to the test's stdin, for tests that
+ * prompt for interactive confirmation (for example "y\ny\n").
+ *
+ * Usage:
+ *   node scripts/run-chip-tests.mjs --start          Create the chip-test container and add/enable the plugin inside it.
+ *   node scripts/run-chip-tests.mjs --stop           Stop the chip-test container, then reinstall, relink, and rebuild the local matterbridge instance.
+ *   node scripts/run-chip-tests.mjs                  Run the tests listed in chipTests.json inside the running container.
+ *   node scripts/run-chip-tests.mjs --test NAME       Run only the tests whose "name" or "test" property includes NAME (case-insensitive).
+ *
+ * A chipTests.json entry may set "resetBefore": true to clear persisted stateful cluster storage (matched
+ * via "resetClusterGlobs", above) and restart the matterbridge process before that test runs, and/or
+ * "resetAfter": true to do the same after that test runs (before the next one starts) — without recreating
+ * the container (no docker rm/pull/npm install/build). This is much cheaper than --start.
+ * "resetBefore" is for tests that depend on starting from a clean, un-allocated device state; "resetAfter"
+ * is for tests that leave dirty residue (e.g. an unclosed session, a mutated attribute) that would otherwise
+ * leak into whichever test runs next — put it on the test that causes the residue, not the one affected by
+ * it, so the fix travels with the test that needs it even if the surrounding list is reordered.
+ * Each yamlTests/phytonTests entry may also set a "comment" string, printed under a failing/skipped result
+ * in the summary log, and a "skip": true flag to leave the test listed (documenting that it exists and why
+ * it doesn't run) without ever invoking it — for tests that can never pass against this image (e.g. ones
+ * requiring the CSA reference app's --app-pipe debug hook, which Matterbridge doesn't implement).
+ */
+
+/* eslint-disable no-console */
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const root = process.cwd();
+const containerName = 'chip-test';
+const image = 'luligu/matterbridge:chip-test';
+const testsFile = resolve(root, 'chipTests.json');
+const logFile = resolve(root, 'chipTests.log');
+const summaryLogFile = resolve(root, 'chipTestsSummary.log');
+// Node storage for the bridged endpoints; only stateful cluster attributes that get written during a
+// test create a file here, so these globs only ever remove test-mutated state, never device identity.
+const matterstorageRoot = '/root/.matterbridge/matterstorage/Matterbridge';
+const isWindows = process.platform === 'win32';
+// On Windows npm is a .cmd shim, not a PE executable: spawnSync can't CreateProcess it directly
+// (ENOENT/EINVAL even when resolved to npm.cmd), so it must be run through the shell.
+const npmCommand = 'npm';
+
+// Populated by loadChipTestsFile(), called first thing in main(): pluginName comes from chipTests.json's
+// "config.name" rather than being hardcoded, so the container's plugin folder, --add, and config file all
+// stay in sync with whatever config.json this repo's chipTests.json declares.
+let pluginName;
+let readyLogMarker;
+let pluginConfig;
+let resetClusterGlobs;
+let allTests;
+
+class ExitError extends Error {
+  constructor(message, code = 1) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function fail(message, code = 1) {
+  throw new ExitError(message, code);
+}
+
+function run(command, args, options = {}) {
+  const { capture = false, shell = false } = options;
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    windowsHide: true,
+    shell,
+  });
+
+  if (result.error) {
+    fail(`Failed to run "${command} ${args.join(' ')}": ${result.error.message}`);
+  }
+
+  return result;
+}
+
+function runOrFail(command, args, options) {
+  const result = run(command, args, options);
+  if (result.status !== 0) {
+    fail(`Command failed (exit ${result.status}): ${command} ${args.join(' ')}`);
+  }
+  return result;
+}
+
+// Safe for the plain alphanumeric/path-like tokens this script passes to npm; quotes anything else for cmd.exe.
+function quoteShellArg(arg) {
+  if (/^[A-Za-z0-9_.\-:/=]+$/.test(arg)) {
+    return arg;
+  }
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+function runNpm(args, options) {
+  if (!isWindows) {
+    return run(npmCommand, args, options);
+  }
+
+  // Node deprecates passing an args array together with shell: true (DEP0190) because the
+  // arguments are not escaped; fold the already-quoted command line into a single string instead.
+  const commandLine = [npmCommand, ...args].map(quoteShellArg).join(' ');
+  return run(commandLine, [], { ...options, shell: true });
+}
+
+function runNpmOrFail(args, options) {
+  const result = runNpm(args, options);
+  if (result.status !== 0) {
+    fail(`Command failed (exit ${result.status}): npm ${args.join(' ')}`);
+  }
+  return result;
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function start() {
+  console.log('Removing any existing chip-test container...');
+  run('docker', ['rm', containerName, '-f']);
+
+  console.log(`Pulling ${image}...`);
+  runOrFail('docker', ['pull', image]);
+
+  // The container needs an IPv6 link-local address (e.g. chip-tool's own traffic to fe80::.../UDP:5540), so
+  // a plain IPv4-only network breaks it — create it with --ipv6 if a fresh host doesn't already have it.
+  if (run('docker', ['network', 'inspect', 'matterbridge'], { capture: true }).status !== 0) {
+    console.log('Creating the matterbridge docker network...');
+    runOrFail('docker', ['network', 'create', '--ipv6', 'matterbridge']);
+  }
+
+  console.log('Starting the chip-test container...');
+  runOrFail('docker', [
+    'run',
+    '-dit',
+    '--network',
+    'matterbridge',
+    '--restart',
+    'always',
+    '--stop-timeout',
+    '60',
+    '--name',
+    containerName,
+    '-p',
+    '8585:8283',
+    '-v',
+    `${join(root, 'temp')}:/tmp/matter_testing/logs`,
+    '-v',
+    `${root}:/root/Matterbridge/${pluginName}`,
+    // Shadows just the node_modules subpath of the bind mount above with a named volume backed by the
+    // container's own native (Linux) filesystem, persisted across container recreations (docker rm doesn't
+    // remove named volumes). Matterbridge core re-links itself into a local plugin's node_modules on every
+    // restart when it isn't already present there (see the comment below); running that npm operation, and
+    // the container's own module resolution generally, against the host's Windows bind mount over Docker
+    // Desktop's cross-OS file sharing is dramatically slower than native disk I/O, and a Windows-created
+    // symlink for node_modules/matterbridge doesn't reliably resolve from inside the Linux container anyway.
+    // With this volume, the container has its own independent node_modules entirely: the first `--start` ever
+    // populates it (a real one-time cost, comparable to a fresh `npm install`), and every one after that finds
+    // node_modules/matterbridge already present and skips straight past the re-link. The host's own
+    // node_modules (used for building dist/, linting, tests, etc.) is never touched by any of this.
+    '-v',
+    `chip-test-node-modules:/root/Matterbridge/${pluginName}/node_modules`,
+    image,
+  ]);
+
+  console.log('Installing dependencies and building the plugin...');
+  runNpmOrFail(['install', '--no-fund', '--no-audit', '--verbose']);
+  runNpmOrFail(['link', 'matterbridge', '--no-fund', '--no-audit', '--verbose']);
+  runNpmOrFail(['run', 'build']);
+  runNpmOrFail(['unlink', 'matterbridge', '--no-fund', '--no-audit']);
+
+  console.log('Adding the plugin to the container...');
+  runOrFail('docker', ['exec', containerName, 'matterbridge', '--add', pluginName]);
+
+  writePluginConfig();
+
+  console.log('Restarting the container...');
+  const restartedAt = new Date().toISOString();
+  runOrFail('docker', ['restart', containerName]);
+  waitForContainerReady(restartedAt);
+  console.log('Chip-test container ready.');
+}
+
+function stop() {
+  console.log('Stopping the chip-test container...');
+  run('docker', ['stop', containerName]);
+
+  console.log('Restoring devDependencies and relinking the local matterbridge instance...');
+  runNpmOrFail(['install', '--no-fund', '--no-audit', '--verbose']);
+  runNpmOrFail(['link', 'matterbridge', '--no-fund', '--no-audit', '--verbose']);
+  runNpmOrFail(['run', 'build']);
+
+  console.log('Chip-test container stopped.');
+}
+
+// Waits for matterbridge to finish re-commissioning its server node after a restart by polling the
+// container logs (only lines emitted since `sinceIso`) for readyLogMarker, so the next test doesn't race a
+// not-yet-ready device. `docker logs` is cumulative for the container's whole lifetime, so without a
+// `--since` anchor a second/subsequent restart would immediately re-match the marker line left over from
+// an earlier boot still sitting in the tail window, returning a false "ready" before the new boot actually
+// gets there.
+function waitForContainerReady(sinceIso, timeoutMs = 45000, pollMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = run('docker', ['logs', '--since', sinceIso, containerName], { capture: true });
+    // Matterbridge colorizes its log output with ANSI escapes even without a TTY, splitting the marker
+    // text across escape sequences (e.g. "Matterbridge " <esc> "is online"); strip them before matching.
+    // eslint-disable-next-line no-control-regex
+    const plainOutput = `${result.stdout ?? ''}${result.stderr ?? ''}`.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+    if (plainOutput.includes(readyLogMarker)) {
+      return;
+    }
+    sleepSync(pollMs);
+  }
+  console.warn(`Timed out waiting for "${readyLogMarker}" in container logs; continuing anyway.`);
+}
+
+// Clears persisted stateful cluster storage and restarts the container (docker restart, not a full
+// recreate: no docker rm/pull/npm install/build), so tests that need a clean, un-allocated device state can
+// run fast without paying the full --start cost between every test. The container restart alone already
+// clears any cluster state that's kept purely in memory and never written to disk (e.g. WebRTC Transport
+// Provider's CurrentSessions) — resetClusterGlobs only needs entries for state that *is* persisted (e.g.
+// CameraAvStreamManagement's allocated streams, Chime state) and would otherwise survive the restart.
+function resetContainerState() {
+  if (resetClusterGlobs.length === 0) {
+    fail(`A test set "resetBefore": true or "resetAfter": true, but ${testsFile} has no (or an empty) "resetClusterGlobs" array to clear.`);
+  }
+
+  console.log('Resetting stateful cluster storage...');
+  const findExpr = resetClusterGlobs.map((glob) => `-name '${glob}'`).join(' -o ');
+  run('docker', ['exec', containerName, 'sh', '-c', `find ${matterstorageRoot} -type f \\( ${findExpr} \\) -delete`]);
+
+  console.log('Restarting matterbridge...');
+  const restartedAt = new Date().toISOString();
+  runOrFail('docker', ['restart', containerName]);
+  waitForContainerReady(restartedAt);
+}
+
+// Reads chipTests.json once, populating pluginName/readyLogMarker/pluginConfig/allTests. Must run before
+// anything that references those, so it's the first thing main() does.
+function loadChipTestsFile() {
+  let raw;
+  try {
+    raw = readFileSync(testsFile, 'utf8');
+  } catch (error) {
+    fail(`Unable to read ${testsFile}: ${error.message}`);
+    return;
+  }
+
+  const parsed = JSON.parse(raw);
+
+  pluginConfig = parsed.config;
+  if (!pluginConfig || !pluginConfig.name) {
+    fail(`Expected a "config" object with a "name" property in ${testsFile}`);
+  }
+  pluginName = pluginConfig.name;
+  // Printed once the plugin has finished (re)configuring its devices after a restart; polled from `docker
+  // logs`. The node coming online happens well before this and is not sufficient: on an already-commissioned
+  // restart the node skips straight to "online", but the plugin (and its cluster state) isn't ready for
+  // another ~30s after that, so waiting on the node-online line alone lets tests race a half-configured plugin.
+  readyLogMarker = `Platform ${pluginName} configured successfully`;
+
+  resetClusterGlobs = parsed.resetClusterGlobs ?? [];
+  if (!Array.isArray(resetClusterGlobs)) {
+    fail(`Expected "resetClusterGlobs" to be an array in ${testsFile}`);
+  }
+
+  const yamlTests = parsed.yamlTests ?? [];
+  if (!Array.isArray(yamlTests)) {
+    fail(`Expected "yamlTests" to be an array in ${testsFile}`);
+  }
+  const phytonTests = parsed.phytonTests ?? [];
+  if (!Array.isArray(phytonTests)) {
+    fail(`Expected "phytonTests" to be an array in ${testsFile}`);
+  }
+
+  allTests = [...yamlTests.map((test) => ({ ...test, kind: 'yaml' })), ...phytonTests.map((test) => ({ ...test, kind: 'python' }))];
+  for (const test of allTests) {
+    if (!test.test) {
+      fail(`Missing "test" name for entry ${JSON.stringify(test)} in ${testsFile}`);
+    }
+  }
+}
+
+// Writes chipTests.json's "config" object into the container's Matterbridge storage directory, so the
+// plugin starts with a known configuration instead of whatever defaults `matterbridge --add` would create.
+function writePluginConfig() {
+  console.log('Writing the plugin config into the container...');
+  const result = spawnSync('docker', ['exec', '-i', containerName, 'sh', '-c', `cat > /root/.matterbridge/${pluginName}.config.json`], {
+    cwd: root,
+    encoding: 'utf8',
+    windowsHide: true,
+    input: `${JSON.stringify(pluginConfig, null, 2)}\n`,
+  });
+  if (result.status !== 0) {
+    fail(`Failed to write the plugin config into the container (exit ${result.status}): ${result.stderr ?? ''}`);
+  }
+}
+
+function buildArgs(test) {
+  const scriptArgs = [];
+  for (const entry of test.args ?? []) {
+    scriptArgs.push(...entry.split(/\s+/).filter(Boolean));
+  }
+  return scriptArgs;
+}
+
+// Builds the argv (after "docker exec -i containerName") for a single test, dispatching on test.kind:
+//   - "python": python3 src/python_testing/<test.test> <args...>
+//   - "yaml":   python3 scripts/tests/chipyaml/chiptool.py tests <test.test> <args...>
+//               Spawns a short-lived "chip-tool interactive server" for the duration of this one test,
+//               reusing chip-tool's own persisted fabric pairing baked into the image.
+function buildExecArgs(test) {
+  const args = buildArgs(test);
+  if (test.kind === 'yaml') {
+    return ['python3', 'scripts/tests/chipyaml/chiptool.py', 'tests', test.test, ...args];
+  }
+  return ['python3', `src/python_testing/${test.test}`, ...args];
+}
+
+function filterTests(tests, nameFilter) {
+  if (!nameFilter) {
+    return tests;
+  }
+
+  const needle = nameFilter.toLowerCase();
+  const filtered = tests.filter((test) => test.name.toLowerCase().includes(needle) || test.test.toLowerCase().includes(needle));
+  if (filtered.length === 0) {
+    fail(`No test found with "name" or "test" including ${JSON.stringify(nameFilter)}`);
+  }
+  return filtered;
+}
+
+function runTests(nameFilter) {
+  const tests = filterTests(allTests, nameFilter);
+  const startedAt = `Chip tests run started at ${new Date().toISOString()}\n\n`;
+  writeFileSync(logFile, startedAt);
+
+  const results = [];
+  for (const test of tests) {
+    const label = `${test.name} (${test.test})`;
+
+    if (test.skip) {
+      console.log(`SKIP: ${label}`);
+      appendFileSync(logFile, `=== ${label} ===\nSkipped ("skip": true set in ${testsFile})\n\n`);
+      results.push({ label, passed: false, skipped: true, comment: test.comment });
+      continue;
+    }
+
+    const execArgs = buildExecArgs(test);
+    const commandLine = execArgs.join(' ');
+
+    if (test.resetBefore) {
+      appendFileSync(logFile, `--- reset stateful cluster storage before ${label} ---\n`);
+      resetContainerState();
+    }
+
+    console.log(`Running: ${label}`);
+    appendFileSync(logFile, `=== ${label} ===\n${commandLine}\n`);
+
+    const result = spawnSync('docker', ['exec', '-i', containerName, ...execArgs], {
+      cwd: root,
+      encoding: 'utf8',
+      windowsHide: true,
+      input: test.input ?? '',
+    });
+
+    appendFileSync(logFile, `${result.stdout ?? ''}${result.stderr ?? ''}\n`);
+
+    const passed = result.status === 0;
+    appendFileSync(logFile, `Result: ${passed ? 'PASS' : 'FAIL'} (exit ${result.status})\n\n`);
+    console.log(passed ? `PASS: ${label}` : `FAIL: ${label} (exit ${result.status})`);
+
+    results.push({ label, passed, comment: test.comment });
+
+    if (test.resetAfter) {
+      appendFileSync(logFile, `--- reset stateful cluster storage after ${label} ---\n`);
+      resetContainerState();
+    }
+  }
+
+  const executedResults = results.filter((result) => !result.skipped);
+  const skippedCount = results.length - executedResults.length;
+  const passedCount = executedResults.filter((result) => result.passed).length;
+  const resultLines = results.flatMap((result) => {
+    const icon = result.skipped ? '⏭️' : result.passed ? '✅' : '❌';
+    const line = `${icon} ${result.label}`;
+    return (result.skipped || !result.passed) && result.comment ? [line, `   ↳ ${result.comment}`] : [line];
+  });
+  const summary = `Summary: ${passedCount}/${executedResults.length} tests passed${skippedCount ? ` (${skippedCount} skipped)` : ''}.`;
+
+  appendFileSync(logFile, `${resultLines.join('\n')}\n\n${summary}\n`);
+  writeFileSync(summaryLogFile, `${startedAt}${resultLines.join('\n')}\n\n${summary}\n`);
+  console.log(resultLines.join('\n'));
+  console.log(summary);
+
+  const unexpectedFailures = executedResults.filter((result) => !result.passed && !result.comment);
+  if (unexpectedFailures.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  loadChipTestsFile();
+
+  if (args.includes('--start')) {
+    start();
+    return;
+  }
+
+  if (args.includes('--stop')) {
+    stop();
+    return;
+  }
+
+  const testFlagIndex = args.indexOf('--test');
+  if (testFlagIndex === -1) {
+    runTests();
+    return;
+  }
+
+  const nameFilter = args[testFlagIndex + 1];
+  if (!nameFilter) {
+    fail('--test requires a NAME argument');
+  }
+  runTests(nameFilter);
+}
+
+try {
+  main();
+} catch (error) {
+  if (error instanceof ExitError) {
+    if (error.message) console.error(error.message);
+    process.exitCode = error.code;
+  } else {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src/coapServer.ts
+++ b/src/coapServer.ts
@@ -163,12 +163,15 @@ export class CoapServer extends EventEmitter<CoapServerEvents> {
           pathname: '/cit/d',
           retrySend: 0,
         })
-        .on('response', (msg: IncomingMessage) => {
-          this.log.debug(`CoIoT (coap) received device description ("/cit/d") code ${BLUE}${msg.code}${db} url ${BLUE}${msg.url}${db} rsinfo ${debugStringify(msg.rsinfo)}:`);
-          msg.url = '/cit/d';
-          this.parseShellyMessage(msg);
-          resolve(msg);
-        })
+        .on(
+          'response',
+          /* v8 ignore next */ (msg: IncomingMessage) => {
+            this.log.debug(`CoIoT (coap) received device description ("/cit/d") code ${BLUE}${msg.code}${db} url ${BLUE}${msg.url}${db} rsinfo ${debugStringify(msg.rsinfo)}:`);
+            msg.url = '/cit/d';
+            this.parseShellyMessage(msg);
+            resolve(msg);
+          },
+        )
         .on(
           'timeout',
           /* v8 ignore next */ (err) => {
@@ -205,11 +208,14 @@ export class CoapServer extends EventEmitter<CoapServerEvents> {
           method: 'GET',
           pathname: '/cit/s',
         })
-        .on('response', (msg: IncomingMessage) => {
-          this.log.debug(`CoIoT (coap) received device status ("/cit/s") code ${BLUE}${msg.code}${db} url ${BLUE}${msg.url}${db} rsinfo ${debugStringify(msg.rsinfo)}:`);
-          this.parseShellyMessage(msg);
-          resolve(msg);
-        })
+        .on(
+          'response',
+          /* v8 ignore next */ (msg: IncomingMessage) => {
+            this.log.debug(`CoIoT (coap) received device status ("/cit/s") code ${BLUE}${msg.code}${db} url ${BLUE}${msg.url}${db} rsinfo ${debugStringify(msg.rsinfo)}:`);
+            this.parseShellyMessage(msg);
+            resolve(msg);
+          },
+        )
         .on(
           'timeout',
           /* v8 ignore next */ (err) => {
@@ -291,7 +297,7 @@ export class CoapServer extends EventEmitter<CoapServerEvents> {
         // Handle null or incompatible types explicitly
         throw new TypeError('Expected a string for GLOBAL_DEVID');
       },
-      (buf) => buf.toString(),
+      /* v8 ignore next */ (buf) => buf.toString(),
     );
 
     coap.registerOption(
@@ -307,7 +313,7 @@ export class CoapServer extends EventEmitter<CoapServerEvents> {
         // Handle null or non-string types explicitly
         throw new TypeError('Expected a string for STATUS_VALIDITY');
       },
-      (buf) => buf.readUInt16LE(0),
+      /* v8 ignore next */ (buf) => buf.readUInt16LE(0),
     );
 
     coap.registerOption(
@@ -323,7 +329,7 @@ export class CoapServer extends EventEmitter<CoapServerEvents> {
         // Handle null or non-string types explicitly
         throw new TypeError('Expected a string for STATUS_SERIAL');
       },
-      (buf) => buf.readUInt16LE(0),
+      /* v8 ignore next */ (buf) => buf.readUInt16LE(0),
     );
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -2017,7 +2017,7 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
     );
     let definition: AtLeastOne<DeviceTypeDefinition> | undefined;
     if (bthomeDevice.model === 'Shelly BLU DoorWindow' || bthomeDevice.model === 'Shelly BLU DoorWindow ZB') definition = [bridgedNode, powerSource];
-    else if (bthomeDevice.model === 'Shelly BLU Motion') definition = [bridgedNode, powerSource];
+    else if (bthomeDevice.model === 'Shelly BLU Motion' || bthomeDevice.model === 'Shelly BLU Motion ZB') definition = [bridgedNode, powerSource];
     else if (bthomeDevice.model === 'Shelly BLU Button1' || bthomeDevice.model === 'Shelly BLU Button Tough 1 ZB') definition = [genericSwitch, bridgedNode, powerSource];
     else if (bthomeDevice.model === 'Shelly BLU HT' || bthomeDevice.model === 'Shelly BLU H&T ZB' || bthomeDevice.model === 'Shelly BLU H&T Display ZB')
       definition = [bridgedNode, powerSource];
@@ -2046,7 +2046,7 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
         void mbDevice.addFixedLabel('composed', 'Sensor');
         mbDevice.addChildDeviceTypeWithClusterServer('Contact', [contactSensor], [], undefined, this.config.debug);
         if (this.validateEntity(bthomeDevice.addr, 'Illuminance')) mbDevice.addChildDeviceTypeWithClusterServer('Illuminance', [lightSensor], [], undefined, this.config.debug);
-      } else if (bthomeDevice.model === 'Shelly BLU Motion') {
+      } else if (bthomeDevice.model === 'Shelly BLU Motion' || bthomeDevice.model === 'Shelly BLU Motion ZB') {
         mbDevice.createDefaultPowerSourceReplaceableBatteryClusterServer();
         void mbDevice.addFixedLabel('composed', 'Sensor');
         mbDevice.addChildDeviceTypeWithClusterServer('Motion', [occupancySensor], [], undefined, this.config.debug);

--- a/src/module.ts
+++ b/src/module.ts
@@ -178,9 +178,9 @@ export class ShellyPlatform extends MatterbridgeDynamicPlatform {
     super(matterbridge, log, config);
 
     // Verify that Matterbridge is the correct version
-    if (typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.9.0')) {
+    if (typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.10.0')) {
       throw new Error(
-        `This plugin requires Matterbridge version >= "3.9.0". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend.`,
+        `This plugin requires Matterbridge version >= "3.10.0". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend.`,
       );
     }
 

--- a/src/shellyDevice.ts
+++ b/src/shellyDevice.ts
@@ -331,6 +331,7 @@ export class ShellyDevice extends EventEmitter<ShellyDeviceEvents> {
       'SBWS-90CM': 'Shelly BLU Weather Station',
       'SBHT-103C': 'Shelly BLU H&T Display ZB',
       'SBHT-203C': 'Shelly BLU H&T ZB',
+      'SBMO-103Z': 'Shelly BLU Motion ZB',
       'SBBT-104CEU': 'Shelly BLU Wall Switch 4 ZB',
       'SBBT-104CUS': 'Shelly BLU RC Button 4 ZB',
       'SBBT-102C': 'Shelly BLU Button Tough 1 ZB',
@@ -378,6 +379,7 @@ export class ShellyDevice extends EventEmitter<ShellyDeviceEvents> {
     try {
       for (const component of components as unknown as BTHomeBluTrvComponent[]) {
         if (component.key.startsWith('blutrv:')) {
+          this.log.debug(`- blutrv:\n${debugStringify(component)}`);
           if (!isValidString(component.key, 6) || !isValidObject(component.status, 5) || !isValidObject(component.config, 5)) {
             this.log.error(
               `BTHome BLUTrv id ${CYAN}${component.config.id}${er} key ${CYAN}${component.key}${er} address ${CYAN}${component.config.addr}${er} has no valid data: ${debugStringify(component)}`,
@@ -396,44 +398,47 @@ export class ShellyDevice extends EventEmitter<ShellyDeviceEvents> {
       }
       for (const component of components as unknown as BTHomeDeviceComponent[]) {
         if (component.key.startsWith('bthomedevice:')) {
+          this.log.debug(`- bthomedevice:\n${debugStringify(component)}`);
           // Shelly BLU gateway doesn't have config.meta.ui.local_name!
           // New paired BTHome devices don't have attrs.model_id
           /* v8 ignore next if cause new paired devices don't have attrs.model_id */
           if (component.attrs?.model_id === 1) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-002C', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-002C', icon: null } }; // 1 - Shelly BLU Button1 / Button Tough 1
           } else if (component.attrs?.model_id === 2) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBDW-002C', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBDW-002C', icon: null } }; // 2 - Shelly BLU Door/Window
           } else if (component.attrs?.model_id === 3) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBHT-003C', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBHT-003C', icon: null } }; // 3 - Shelly BLU H&T
           } else if (component.attrs?.model_id === 5) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBMO-003Z', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBMO-003Z', icon: null } }; // 5 - Shelly BLU Motion
           } else if (component.attrs?.model_id === 6) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-004CEU', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-004CEU', icon: null } }; // 6 - Shelly BLU Wall Switch 4
           } else if (component.attrs?.model_id === 7) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-004CUS', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-004CUS', icon: null } }; // 7 - Shelly BLU RC Button 4
           } else if (component.attrs?.model_id === 8) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'TRV', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'TRV', icon: null } }; // 8 - Shelly BLU TRV (SBTR-001AEU)
           } else if (component.attrs?.model_id === 9) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBRC-005B', icon: null } }; // 9 -Shelly BLU Remote Control ZB
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBRC-005B', icon: null } }; // 9 - Shelly BLU Remote Control ZB
           } else if (component.attrs?.model_id === 0xb) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBWS-90CM', icon: null } }; // 11 -Shelly BLU Weather Station
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBWS-90CM', icon: null } }; // 11 - Shelly BLU Weather Station
           } else if (component.attrs?.model_id === 0xc) {
             component.config.meta = { ui: { view: 'regular', local_name: 'SBHT-103C', icon: null } }; // 12 - Shelly BLU H&T Display ZB
           } else if (component.attrs?.model_id === 0x11) {
             component.config.meta = { ui: { view: 'regular', local_name: 'SBHT-203C', icon: null } }; // 17 - Shelly BLU H&T ZB
+          } else if (component.attrs?.model_id === 0x13) {
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBMO-103Z', icon: null } }; // 19 - Shelly BLU Motion ZB
           } else if (component.attrs?.model_id === 0x14) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBDW-103C', icon: null } };
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBDW-103C', icon: null } }; // 20 - Shelly BLU Door/Window ZB
           } else if (component.attrs?.model_id === 0x15) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-104CEU', icon: null } }; // 21 -Shelly BLU Wall Switch 4 ZB
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-104CEU', icon: null } }; // 21 - Shelly BLU Wall Switch 4 ZB
           } else if (component.attrs?.model_id === 0x16) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-104CUS', icon: null } }; // 22 -Shelly BLU RC Button 4 ZB
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-104CUS', icon: null } }; // 22 - Shelly BLU RC Button 4 ZB
           } else if (component.attrs?.model_id === 0x17) {
-            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-102C', icon: null } }; // 23 -Shelly BLU Button Tough 1 ZB
+            component.config.meta = { ui: { view: 'regular', local_name: 'SBBT-102C', icon: null } }; // 23 - Shelly BLU Button Tough 1 ZB
           }
           if (
             !isValidString(component.key, 12) ||
             !isValidObject(component.status, 5) ||
-            !isValidObject(component.config, 5) ||
+            !isValidObject(component.config, 4) ||
             !isValidObject(component.config.meta, 1) ||
             !isValidObject(component.config.meta.ui, 2) ||
             !isValidString(component.config.meta.ui.local_name)
@@ -469,6 +474,7 @@ export class ShellyDevice extends EventEmitter<ShellyDeviceEvents> {
       }
       for (const component of components as unknown as BTHomeSensorComponent[]) {
         if (component.key.startsWith('bthomesensor:')) {
+          this.log.debug(`- bthomesensor:\n${debugStringify(component)}`);
           if (
             !isValidString(component.key, 12) ||
             !isValidObject(component.status, 1) ||

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-// vite.config.ts 2.0.5
+// vite.config.ts 2.0.6
 
 // This Vitest configuration is designed for a TypeScript project.
 
@@ -6,6 +6,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   cacheDir: '.cache/vitest',
+  envDir: false,
   test: {
     include: ['**/vitest/**/*.{spec,test}.{ts,mts,cts}'],
     exclude: [


### PR DESCRIPTION
## [2.5.1] - 2026-08-09

### Firmware 2.0.0

- [shelly]: The new firmware 2.0.0 is still under test. At the moment I see very frequent websocket disconnections.

### Breaking changes

- [matterbridge]: Require matterbridge v.3.10.0 with matter v.1.6.0.

### Added

- [chip]: Add chip-test toolchain agents instruction and chip-test runner.
- [frontend]: Add plugin-frontend agents instructions.
- [blu]: Add `Shelly BLU Motion ZB` (`SBMO-103Z`).
- [blu]: Verified `BLU Door Window ZB` with firmware 1.2.23.
- [blu]: Verified `BLU H&T ZB` with firmware 1.2.12.

### Fixed

- [blu]: Fix BTHome device validation rejecting all `bthomedevice:*` components on gateway firmware 2.0.0+: the gateway now omits the `key` property from `config` (down to 4 properties: `id`, `name`, `addr`, `meta`) instead of sending it as `null`, even though the Shelly API docs still document `key` as part of the `BTHomeDevice` config schema. Relaxed the config validation minimum from 5 to 4 properties.

### Changed

- [package]: Bump `ws` to v.8.21.3.
- [package]: Bump `oxfmt` to v.0.62.0.
- [package]: Bump `oxlint` to v.1.77.0.
- [package]: Bump `oxlint-tsgolint` to v.7.0.2001.
- [package]: Bump `@types/node` to v.26.2.0.
- [package]: Update agents configs.
- [package]: Update dependencies.
- [package]: Upgrade package.

<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
